### PR TITLE
Feat/additional requirements and revocation-like criterion

### DIFF
--- a/avida-ts/README.md
+++ b/avida-ts/README.md
@@ -24,7 +24,7 @@ Then we can bring up docker containers:
 
 ```bash
 # starting in ./avida-ts
-docker-compose -f ./docker/docker-compose.local.yaml up -d
+docker-compose -f ./docker/docker-compose.local.yaml up --remove-orphans
 ```
 This does several things
 1. `scripts/cheqd-genesis.sh` creates a cheqd node with a genesis tx to pre-fund the relayer and resource owner accounts.
@@ -35,6 +35,7 @@ This does several things
 
 
 > The local network takes a few mins to start up, please wait for the relayer to start before running the demo.
+> You can check the logs of the relayer to see when it is ready by looking for `AVIDA Path created!`
 
 ## Run demo
 
@@ -43,7 +44,10 @@ This does several things
 > The local network takes a few mins to start up, please wait for the relayer to start before running the demo.
 
 ```
-pnpm i
-pnpm run build:packages
+pnpm setup
+pnpm run build
+echo CONTRACT_ADDRESS= > ./env/local.contract
+docker-compose -f ./docker/docker-compose.local.yaml up --remove-orphans
+# wait until you get the message "AVIDA Path created!" or follow `hermer-relayer-1` logs
 pnpm run local-demo
 ```

--- a/avida-ts/packages/avida-common-types/package.json
+++ b/avida-ts/packages/avida-common-types/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@avida-ts/types",
-<<<<<<< HEAD
   "version": "0.1.0",
   "type": "module",
   "main": "dist/index.ts",
@@ -17,7 +16,4 @@
     "typescript": "^5.4.5",
     "type-fest": "4.20.1"
   }
-=======
-  "version": "0.1.0"
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
 }

--- a/avida-ts/packages/avida-common-types/src/contracts/RestaurantContract.types.ts
+++ b/avida-ts/packages/avida-common-types/src/contracts/RestaurantContract.types.ts
@@ -37,10 +37,10 @@ export type RegisterRequirement = {
 export type Binary = string;
 export type TrustRegistry = "cheqd";
 export interface RouteVerificationRequirements {
-  presentation_request: Binary;
-  verification_source: VerificationSource;
+  issuer_source_or_data: IssuerSourceOrData;
+  presentation_required: Binary;
 }
-export interface VerificationSource {
+export interface IssuerSourceOrData {
   data_or_location: Binary;
   source?: TrustRegistry | null;
 }

--- a/avida-ts/packages/avida-common-types/src/contracts/SdjwtVerifier.types.ts
+++ b/avida-ts/packages/avida-common-types/src/contracts/SdjwtVerifier.types.ts
@@ -14,17 +14,17 @@ export interface InstantiateMsg {
 export interface InitRegistration {
   app_addr: string;
   app_admin: string;
-  routes: InputRoutesRequirements[];
+  routes: RegisterRouteRequest[];
 }
-export interface InputRoutesRequirements {
+export interface RegisterRouteRequest {
   requirements: RouteVerificationRequirements;
   route_id: number;
 }
 export interface RouteVerificationRequirements {
-  presentation_request: Binary;
-  verification_source: VerificationSource;
+  issuer_source_or_data: IssuerSourceOrData;
+  presentation_required: Binary;
 }
-export interface VerificationSource {
+export interface IssuerSourceOrData {
   data_or_location: Binary;
   source?: TrustRegistry | null;
 }
@@ -32,11 +32,12 @@ export type ExecuteMsg = AvidaVerifierTraitExecMsg | ExecMsg;
 export type AvidaVerifierTraitExecMsg = {
   register: {
     app_addr: string;
-    route_criteria: InputRoutesRequirements[];
+    requests: RegisterRouteRequest[];
     [k: string]: unknown;
   };
 } | {
   verify: {
+    additional_requirements?: Binary | null;
     app_addr?: string | null;
     presentation: Binary;
     route_id: number;
@@ -55,7 +56,18 @@ export type AvidaVerifierTraitExecMsg = {
     [k: string]: unknown;
   };
 };
-export type ExecMsg = string;
+export type ExecMsg = {
+  update_revocation_list: {
+    app_addr: string;
+    request: UpdateRevocationListRequest;
+    [k: string]: unknown;
+  };
+};
+export interface UpdateRevocationListRequest {
+  revoke: number[];
+  route_id: number;
+  unrevoke: number[];
+}
 export type QueryMsg = AvidaVerifierTraitQueryMsg | QueryMsg1;
 export type AvidaVerifierTraitQueryMsg = {
   get_routes: {

--- a/avida-ts/packages/avida-common-types/src/sdjwt.ts
+++ b/avida-ts/packages/avida-common-types/src/sdjwt.ts
@@ -5,5 +5,7 @@ export type CriterionKey = string;
 export type Criterion =
   | { string: string }
   | { number: [number, MathsOperator] }
-  | { boolean: boolean };
+  | { boolean: boolean }
+  | { expires: string }
+  | { not_contained_in: Array<number> };
 export type MathsOperator = "greater_than" | "less_than" | "equal_to";

--- a/avida-ts/pnpm-lock.yaml
+++ b/avida-ts/pnpm-lock.yaml
@@ -126,6 +126,22 @@ importers:
       cosmes:
         specifier: nymlab/cosmes#f9c4e4ef3f
         version: https://codeload.github.com/nymlab/cosmes/tar.gz/f9c4e4ef3f(@bufbuild/protobuf@1.10.0)(@noble/hashes@1.4.0)(@noble/secp256k1@2.1.0)(@scure/base@1.1.6)(@scure/bip32@1.4.0)(@scure/bip39@1.3.0)(@walletconnect/legacy-client@2.0.0)(@walletconnect/sign-client@2.8.6)(lodash-es@4.17.21)
+      neverthrow:
+        specifier: ^6.2.2
+        version: 6.2.2
+    devDependencies:
+      tsup:
+        specifier: ^8.1.0
+        version: 8.1.0(typescript@5.4.5)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.4.5
+
+  packages/deployer:
+    dependencies:
+      cosmes:
+        specifier: nymlab/cosmes#f9c4e4ef3f
+        version: https://codeload.github.com/nymlab/cosmes/tar.gz/f9c4e4ef3f(@bufbuild/protobuf@1.10.0)(@noble/hashes@1.4.0)(@noble/secp256k1@2.1.0)(@scure/base@1.1.6)(@scure/bip32@1.4.0)(@scure/bip39@1.3.0)(@walletconnect/legacy-client@2.0.0)(@walletconnect/sign-client@2.8.6)(lodash-es@4.17.21)
     devDependencies:
       tsup:
         specifier: ^8.1.0
@@ -2919,6 +2935,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  neverthrow@6.2.2:
+    resolution: {integrity: sha512-POR1FACqdK9jH0S2kRPzaZEvzT11wsOxLW520PQV/+vKi9dQe+hXq19EiOvYx7lSRaF5VB9lYGsPInynrnN05w==}
+
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
@@ -3996,89 +4015,40 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/generator@7.18.12':
-=======
-    dev: true
-
-  /@babel/generator@7.18.12:
-    resolution: {integrity: sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/types': 7.18.10
       '@jridgewell/gen-mapping': 0.3.5
       jsesc: 2.5.2
-<<<<<<< HEAD
 
   '@babel/generator@7.24.7':
-=======
-    dev: true
-
-  /@babel/generator@7.24.7:
-    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/types': 7.24.7
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
-<<<<<<< HEAD
 
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
       '@babel/types': 7.24.7
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-annotate-as-pure@7.24.7:
-    resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/helper-builder-binary-assignment-operator-visitor@7.24.7:
-    resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-compilation-targets@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-compilation-targets@7.24.7:
-    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/compat-data': 7.24.7
       '@babel/helper-validator-option': 7.24.7
       browserslist: 4.23.0
       lru-cache: 5.1.1
       semver: 6.3.1
-<<<<<<< HEAD
 
   '@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -4092,34 +4062,15 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
       semver: 6.3.1
-<<<<<<< HEAD
 
   '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-compilation-targets': 7.24.7
@@ -4130,7 +4081,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
@@ -4146,67 +4096,20 @@ snapshots:
       '@babel/types': 7.24.7
 
   '@babel/helper-member-expression-to-functions@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-environment-visitor@7.24.7:
-    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/helper-function-name@7.24.7:
-    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/helper-hoist-variables@7.24.7:
-    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/helper-member-expression-to-functions@7.24.7:
-    resolution: {integrity: sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-module-imports@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-module-imports@7.24.7:
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-module-transforms@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/helper-module-transforms@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-environment-visitor': 7.24.7
@@ -4216,7 +4119,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
@@ -4225,27 +4127,6 @@ snapshots:
   '@babel/helper-plugin-utils@7.24.7': {}
 
   '@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/helper-optimise-call-expression@7.24.7:
-    resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/helper-plugin-utils@7.24.7:
-    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -4253,18 +4134,8 @@ snapshots:
       '@babel/helper-wrap-function': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-replace-supers@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/helper-replace-supers@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-environment-visitor': 7.24.7
@@ -4272,37 +4143,20 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-simple-access@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-simple-access@7.24.7:
-    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-skip-transparent-expression-wrappers@7.24.7:
-    resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
@@ -4315,35 +4169,6 @@ snapshots:
   '@babel/helper-validator-option@7.24.7': {}
 
   '@babel/helper-wrap-function@7.24.7':
-=======
-    dev: true
-
-  /@babel/helper-split-export-declaration@7.24.7:
-    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/helper-string-parser@7.24.7:
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-validator-identifier@7.24.7:
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-validator-option@7.24.7:
-    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-wrap-function@7.24.7:
-    resolution: {integrity: sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/helper-function-name': 7.24.7
       '@babel/template': 7.24.7
@@ -4351,7 +4176,6 @@ snapshots:
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/helpers@7.24.7':
     dependencies:
@@ -4359,27 +4183,11 @@ snapshots:
       '@babel/types': 7.24.7
 
   '@babel/highlight@7.24.7':
-=======
-    dev: true
-
-  /@babel/helpers@7.24.7:
-    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/highlight@7.24.7:
-    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.0.1
-<<<<<<< HEAD
 
   '@babel/parser@7.18.11':
     dependencies:
@@ -4395,41 +4203,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/parser@7.18.11:
-    resolution: {integrity: sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.18.10
-    dev: true
-
-  /@babel/parser@7.24.7:
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.24.7
-    dev: true
-
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.13.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
@@ -4437,19 +4210,8 @@ snapshots:
       '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-environment-visitor': 7.24.7
@@ -4458,38 +4220,16 @@ snapshots:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.18.10):
-    resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-static-block instead.
-    peerDependencies:
-      '@babel/core': ^7.12.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.18.10)
@@ -4497,137 +4237,50 @@ snapshots:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-export-default-from@7.18.10(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-export-default-from@7.18.10(@babel/core@7.18.10):
-    resolution: {integrity: sha512-5H2N3R2aQFxkV4PIBUR/i7PUSwgTZjouJKzI8eKswfIjT0PhvzkPn0t0wIS5zn6maQuvtT0t1oHtMUz61LOuow==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.18.10):
-    resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-json-strings instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-object-rest-spread@7.18.9(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-object-rest-spread@7.18.9(@babel/core@7.18.10):
-    resolution: {integrity: sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/compat-data': 7.24.7
       '@babel/core': 7.18.10
@@ -4635,36 +4288,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.18.10)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.18.10)
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.18.10):
-    resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
@@ -4672,38 +4303,16 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.18.10):
-    resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -4712,24 +4321,12 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
-    engines: {node: '>=4'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
-<<<<<<< HEAD
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.18.10)':
     dependencies:
@@ -4827,194 +4424,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.18.10):
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.18.10):
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.18.10):
-    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-export-default-from@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-bTPz4/635WQ9WhwsyPdxUJDVpsi/X9BMmy/8Rf/UAlOO4jSql4CxUCjWI5PiM+jG+c4LVPTScoTw80geFj9+Bw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.18.10):
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.18.10):
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.18.10):
-    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.18.10):
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-module-imports': 7.24.7
@@ -5022,7 +4431,6 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5035,35 +4443,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-classes@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-block-scoping@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-classes@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -5076,23 +4455,12 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/template': 7.24.7
-<<<<<<< HEAD
 
   '@babel/plugin-transform-destructuring@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5100,30 +4468,10 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-destructuring@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
-<<<<<<< HEAD
 
   '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5131,67 +4479,27 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-for-of@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-function-name@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-function-name@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-<<<<<<< HEAD
 
   '@babel/plugin-transform-literals@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5204,53 +4512,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-literals@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-module-transforms': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-modules-commonjs@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-modules-commonjs@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-module-transforms': 7.24.7(@babel/core@7.18.10)
@@ -5258,18 +4527,8 @@ snapshots:
       '@babel/helper-simple-access': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-modules-systemjs@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-modules-systemjs@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-hoist-variables': 7.24.7
@@ -5278,41 +4537,20 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-module-transforms': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
-<<<<<<< HEAD
 
   '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5320,43 +4558,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-new-target@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-object-super@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-replace-supers': 7.24.7(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
@@ -5364,7 +4573,6 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5377,40 +4585,10 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-parameters@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       regenerator-transform: 0.15.2
-<<<<<<< HEAD
 
   '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5418,25 +4596,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-runtime@7.18.10(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-runtime@7.18.10(@babel/core@7.18.10):
-    resolution: {integrity: sha512-q5mMeYAdfEbpBAgzl7tBre/la3LeCxmDO1+wMXRdPWbcoMjR3GiXlCLk7JBZVVye0bqTGNMbt0yYVXX1B1jEWQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-module-imports': 7.24.7
@@ -5447,7 +4606,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5455,32 +4613,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-spread@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-spread@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5498,45 +4636,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-typescript@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-typeof-symbol@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-typescript@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -5545,7 +4644,6 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.18.10)':
     dependencies:
@@ -5553,41 +4651,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.24.7
-<<<<<<< HEAD
 
   '@babel/preset-env@7.18.10(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/preset-env@7.18.10(@babel/core@7.18.10):
-    resolution: {integrity: sha512-wVxs1yjFdW3Z/XkNfXKoblxoHgbtUF7/l3PvvP4m02Qz9TZ6uZGxRVYjSQeR87oQmHco9zWitW5J82DJ7sCjvA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/compat-data': 7.24.7
       '@babel/core': 7.18.10
@@ -5667,17 +4736,8 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/preset-modules@0.1.6(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/preset-modules@0.1.6(@babel/core@7.18.10):
-    resolution: {integrity: sha512-ID2yj6K/4lKfhuU3+EX4UvNbIt7eACFbHmNUjzA+ep+B5971CknnA/9DEWKbRokfbbtblxxxXFJJrH47UEAMVg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
@@ -5685,18 +4745,8 @@ snapshots:
       '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.18.10)
       '@babel/types': 7.18.10
       esutils: 2.0.3
-<<<<<<< HEAD
 
   '@babel/preset-typescript@7.24.7(@babel/core@7.18.10)':
-=======
-    dev: true
-
-  /@babel/preset-typescript@7.24.7(@babel/core@7.18.10):
-    resolution: {integrity: sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.24.7
@@ -5706,7 +4756,6 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/regjsgen@0.8.0': {}
 
@@ -5715,38 +4764,12 @@ snapshots:
       regenerator-runtime: 0.14.1
 
   '@babel/template@7.24.7':
-=======
-    dev: true
-
-  /@babel/regjsgen@0.8.0:
-    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
-    dev: true
-
-  /@babel/runtime@7.24.7:
-    resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.1
-    dev: true
-
-  /@babel/template@7.24.7:
-    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
-<<<<<<< HEAD
 
   '@babel/traverse@7.18.11':
-=======
-    dev: true
-
-  /@babel/traverse@7.18.11:
-    resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/generator': 7.18.12
@@ -5760,16 +4783,8 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/traverse@7.24.7':
-=======
-    dev: true
-
-  /@babel/traverse@7.24.7:
-    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.7
@@ -5783,50 +4798,22 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@babel/types@7.18.10':
-=======
-    dev: true
-
-  /@babel/types@7.18.10:
-    resolution: {integrity: sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/helper-string-parser': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
-<<<<<<< HEAD
 
   '@babel/types@7.24.7':
-=======
-    dev: true
-
-  /@babel/types@7.24.7:
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
-    engines: {node: '>=6.9.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/helper-string-parser': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
-<<<<<<< HEAD
 
   '@bufbuild/protobuf@1.10.0': {}
 
   '@cosmwasm/ts-codegen@0.35.7':
-=======
-    dev: true
-
-  /@bufbuild/protobuf@1.2.0:
-    resolution: {integrity: sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g==}
-    dev: false
-
-  /@cosmwasm/ts-codegen@0.35.7:
-    resolution: {integrity: sha512-qbOAYJPe5O5AjoWytZcsVvM0SBA39sMpiqnVIIgjJiqp4G4D5GjR2/UV3ePpygnIxxKZWMnOpPPUvLMjflblCw==}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/generator': 7.18.12
@@ -5857,7 +4844,6 @@ snapshots:
       wasm-ast-types: 0.26.4
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@effect/schema@0.66.5(effect@3.0.3)(fast-check@3.17.2)':
     dependencies:
@@ -5943,266 +4929,14 @@ snapshots:
   '@eslint/compat@1.0.3': {}
 
   '@eslint/config-array@0.15.1':
-=======
-    dev: true
-
-  /@effect/schema@0.66.5(effect@3.0.3)(fast-check@3.17.2):
-    resolution: {integrity: sha512-xfu5161JyrfAS1Ruwv0RXd4QFiCALbm3iu9nlW9N9K+52wbS0WdO6XUekPZ9V/O7LN+XmlIh5Y9xhJaIWCZ/gw==}
-    peerDependencies:
-      effect: ^3.0.3
-      fast-check: ^3.13.2
-    dependencies:
-      effect: 3.0.3
-      fast-check: 3.17.2
-    dev: true
-
-  /@esbuild/aix-ppc64@0.21.4:
-    resolution: {integrity: sha512-Zrm+B33R4LWPLjDEVnEqt2+SLTATlru1q/xYKVn8oVTbiRBGmK2VIMoIYGJDGyftnGaC788IuzGFAlb7IQ0Y8A==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64@0.21.4:
-    resolution: {integrity: sha512-fYFnz+ObClJ3dNiITySBUx+oNalYUT18/AryMxfovLkYWbutXsct3Wz2ZWAcGGppp+RVVX5FiXeLYGi97umisA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.21.4:
-    resolution: {integrity: sha512-E7H/yTd8kGQfY4z9t3nRPk/hrhaCajfA3YSQSBrst8B+3uTcgsi8N+ZWYCaeIDsiVs6m65JPCaQN/DxBRclF3A==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.21.4:
-    resolution: {integrity: sha512-mDqmlge3hFbEPbCWxp4fM6hqq7aZfLEHZAKGP9viq9wMUBVQx202aDIfc3l+d2cKhUJM741VrCXEzRFhPDKH3Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.21.4:
-    resolution: {integrity: sha512-72eaIrDZDSiWqpmCzVaBD58c8ea8cw/U0fq/PPOTqE3c53D0xVMRt2ooIABZ6/wj99Y+h4ksT/+I+srCDLU9TA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.21.4:
-    resolution: {integrity: sha512-uBsuwRMehGmw1JC7Vecu/upOjTsMhgahmDkWhGLWxIgUn2x/Y4tIwUZngsmVb6XyPSTXJYS4YiASKPcm9Zitag==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.21.4:
-    resolution: {integrity: sha512-8JfuSC6YMSAEIZIWNL3GtdUT5NhUA/CMUCpZdDRolUXNAXEE/Vbpe6qlGLpfThtY5NwXq8Hi4nJy4YfPh+TwAg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.21.4:
-    resolution: {integrity: sha512-8d9y9eQhxv4ef7JmXny7591P/PYsDFc4+STaxC1GBv0tMyCdyWfXu2jBuqRsyhY8uL2HU8uPyscgE2KxCY9imQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.21.4:
-    resolution: {integrity: sha512-/GLD2orjNU50v9PcxNpYZi+y8dJ7e7/LhQukN3S4jNDXCKkyyiyAz9zDw3siZ7Eh1tRcnCHAo/WcqKMzmi4eMQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.21.4:
-    resolution: {integrity: sha512-2rqFFefpYmpMs+FWjkzSgXg5vViocqpq5a1PSRgT0AvSgxoXmGF17qfGAzKedg6wAwyM7UltrKVo9kxaJLMF/g==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.21.4:
-    resolution: {integrity: sha512-pNftBl7m/tFG3t2m/tSjuYeWIffzwAZT9m08+9DPLizxVOsUl8DdFzn9HvJrTQwe3wvJnwTdl92AonY36w/25g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.21.4:
-    resolution: {integrity: sha512-cSD2gzCK5LuVX+hszzXQzlWya6c7hilO71L9h4KHwqI4qeqZ57bAtkgcC2YioXjsbfAv4lPn3qe3b00Zt+jIfQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.21.4:
-    resolution: {integrity: sha512-qtzAd3BJh7UdbiXCrg6npWLYU0YpufsV9XlufKhMhYMJGJCdfX/G6+PNd0+v877X1JG5VmjBLUiFB0o8EUSicA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.21.4:
-    resolution: {integrity: sha512-yB8AYzOTaL0D5+2a4xEy7OVvbcypvDR05MsB/VVPVA7nL4hc5w5Dyd/ddnayStDgJE59fAgNEOdLhBxjfx5+dg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.21.4:
-    resolution: {integrity: sha512-Y5AgOuVzPjQdgU59ramLoqSSiXddu7F3F+LI5hYy/d1UHN7K5oLzYBDZe23QmQJ9PIVUXwOdKJ/jZahPdxzm9w==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.21.4:
-    resolution: {integrity: sha512-Iqc/l/FFwtt8FoTK9riYv9zQNms7B8u+vAI/rxKuN10HgQIXaPzKZc479lZ0x6+vKVQbu55GdpYpeNWzjOhgbA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.21.4:
-    resolution: {integrity: sha512-Td9jv782UMAFsuLZINfUpoF5mZIbAj+jv1YVtE58rFtfvoKRiKSkRGQfHTgKamLVT/fO7203bHa3wU122V/Bdg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.21.4:
-    resolution: {integrity: sha512-Awn38oSXxsPMQxaV0Ipb7W/gxZtk5Tx3+W+rAPdZkyEhQ6968r9NvtkjhnhbEgWXYbgV+JEONJ6PcdBS+nlcpA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.21.4:
-    resolution: {integrity: sha512-IsUmQeCY0aU374R82fxIPu6vkOybWIMc3hVGZ3ChRwL9hA1TwY+tS0lgFWV5+F1+1ssuvvXt3HFqe8roCip8Hg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.21.4:
-    resolution: {integrity: sha512-hsKhgZ4teLUaDA6FG/QIu2q0rI6I36tZVfM4DBZv3BG0mkMIdEnMbhc4xwLvLJSS22uWmaVkFkqWgIS0gPIm+A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.21.4:
-    resolution: {integrity: sha512-UUfMgMoXPoA/bvGUNfUBFLCh0gt9dxZYIx9W4rfJr7+hKe5jxxHmfOK8YSH4qsHLLN4Ck8JZ+v7Q5fIm1huErg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.21.4:
-    resolution: {integrity: sha512-yIxbspZb5kGCAHWm8dexALQ9en1IYDfErzjSEq1KzXFniHv019VT3mNtTK7t8qdy4TwT6QYHI9sEZabONHg+aw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.21.4:
-    resolution: {integrity: sha512-sywLRD3UK/qRJt0oBwdpYLBibk7KiRfbswmWRDabuncQYSlf8aLEEUor/oP6KRz8KEG+HoiVLBhPRD5JWjS8Sg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@eslint-community/eslint-utils@4.4.0(eslint@9.4.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 9.4.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
-  /@eslint-community/regexpp@4.10.1:
-    resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/compat@1.0.3:
-    resolution: {integrity: sha512-9RaroPQaU2+SDcWav1YfuipwqnHccoiXZdUsicRQsQ/vH2wkEmRVcj344GapG/FnCeZRtqj0n6PshI+s9xkkAQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
-  /@eslint/config-array@0.15.1:
-    resolution: {integrity: sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@eslint/object-schema': 2.1.3
       debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@eslint/eslintrc@3.1.0':
-=======
-    dev: true
-
-  /@eslint/eslintrc@3.1.0:
-    resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ajv: 6.12.6
       debug: 4.3.5
@@ -6215,7 +4949,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@eslint/js@9.4.0': {}
 
@@ -6235,52 +4968,12 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@istanbuljs/load-nyc-config@1.1.0':
-=======
-    dev: true
-
-  /@eslint/js@9.4.0:
-    resolution: {integrity: sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
-  /@eslint/object-schema@2.1.3:
-    resolution: {integrity: sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
-  /@humanwhocodes/module-importer@1.0.1:
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
-    dev: true
-
-  /@humanwhocodes/retry@0.3.0:
-    resolution: {integrity: sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==}
-    engines: {node: '>=18.18'}
-    dev: true
-
-  /@isaacs/cliui@8.0.2:
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: /string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: /strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
-
-  /@istanbuljs/load-nyc-config@1.1.0:
-    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
       js-yaml: 3.14.1
       resolve-from: 5.0.0
-<<<<<<< HEAD
 
   '@istanbuljs/schema@0.1.3': {}
 
@@ -6289,25 +4982,6 @@ snapshots:
       '@sinclair/typebox': 0.24.51
 
   '@jest/transform@28.1.3':
-=======
-    dev: true
-
-  /@istanbuljs/schema@0.1.3:
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /@jest/schemas@28.1.3:
-    resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.24.51
-    dev: true
-
-  /@jest/transform@28.1.3:
-    resolution: {integrity: sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@jest/types': 28.1.3
@@ -6326,16 +5000,8 @@ snapshots:
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   '@jest/types@28.1.3':
-=======
-    dev: true
-
-  /@jest/types@28.1.3:
-    resolution: {integrity: sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.6
@@ -6343,21 +5009,12 @@ snapshots:
       '@types/node': 20.14.2
       '@types/yargs': 17.0.32
       chalk: 4.1.2
-<<<<<<< HEAD
 
   '@jridgewell/gen-mapping@0.3.5':
-=======
-    dev: true
-
-  /@jridgewell/gen-mapping@0.3.5:
-    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
-    engines: {node: '>=6.0.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.25
-<<<<<<< HEAD
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -6434,192 +5091,6 @@ snapshots:
     optional: true
 
   '@parcel/watcher@2.4.1':
-=======
-    dev: true
-
-  /@jridgewell/resolve-uri@3.1.2:
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/set-array@1.2.1:
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
-
-  /@jridgewell/trace-mapping@0.3.25:
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
-
-  /@jsdevtools/ono@7.1.3:
-    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
-    dev: true
-
-  /@noble/curves@1.4.0:
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
-    dependencies:
-      '@noble/hashes': 1.4.0
-    dev: false
-
-  /@noble/hashes@1.4.0:
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
-    engines: {node: '>= 16'}
-    dev: false
-
-  /@noble/secp256k1@2.1.0:
-    resolution: {integrity: sha512-XLEQQNdablO0XZOIniFQimiXsZDNwaYgL96dZwC54Q30imSbAOFf3NKtepc+cXyuZf5Q1HCgbqgZ2UFFuHVcEw==}
-    dev: false
-
-  /@nodelib/fs.scandir@2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-    dev: true
-
-  /@nodelib/fs.stat@2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /@nodelib/fs.walk@1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.17.1
-    dev: true
-
-  /@parcel/watcher-android-arm64@2.4.1:
-    resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-darwin-arm64@2.4.1:
-    resolution: {integrity: sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-darwin-x64@2.4.1:
-    resolution: {integrity: sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-freebsd-x64@2.4.1:
-    resolution: {integrity: sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-linux-arm-glibc@2.4.1:
-    resolution: {integrity: sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-linux-arm64-glibc@2.4.1:
-    resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-linux-arm64-musl@2.4.1:
-    resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-linux-x64-glibc@2.4.1:
-    resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-linux-x64-musl@2.4.1:
-    resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-wasm@2.4.1:
-    resolution: {integrity: sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      is-glob: 4.0.3
-      micromatch: 4.0.7
-    dev: false
-    bundledDependencies:
-      - napi-wasm
-
-  /@parcel/watcher-win32-arm64@2.4.1:
-    resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-win32-ia32@2.4.1:
-    resolution: {integrity: sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher-win32-x64@2.4.1:
-    resolution: {integrity: sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@parcel/watcher@2.4.1:
-    resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
-    engines: {node: '>= 10.0.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       detect-libc: 1.0.3
       is-glob: 4.0.3
@@ -6638,7 +5109,6 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.4.1
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
-<<<<<<< HEAD
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6646,39 +5116,12 @@ snapshots:
   '@pkgr/core@0.1.1': {}
 
   '@pyramation/json-schema-ref-parser@9.0.6':
-=======
-    dev: false
-
-  /@pkgjs/parseargs@0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@pkgr/core@0.1.1:
-    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    dev: true
-
-  /@pyramation/json-schema-ref-parser@9.0.6:
-    resolution: {integrity: sha512-L5kToHAEc1Q87R8ZwWFaNa4tPHr8Hnm+U+DRdUVq3tUtk+EX4pCqSd34Z6EMxNi/bjTzt1syAG9J2Oo1YFlqSg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@jsdevtools/ono': 7.1.3
       call-me-maybe: 1.0.2
       js-yaml: 3.14.1
-<<<<<<< HEAD
 
   '@pyramation/json-schema-to-typescript@11.0.4':
-=======
-    dev: true
-
-  /@pyramation/json-schema-to-typescript@11.0.4:
-    resolution: {integrity: sha512-+aSzXDLhMHOEdV2cJ7Tjg/9YenjHU5BCmClVygzwxJZ1R16NOfEn7lTAwVzb/2jivOSnhjHzMJbnSf8b6rd1zg==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@pyramation/json-schema-ref-parser': 9.0.6
       '@types/json-schema': 7.0.15
@@ -6694,7 +5137,6 @@ snapshots:
       mkdirp: 1.0.4
       mz: 2.7.0
       prettier: 2.8.8
-<<<<<<< HEAD
 
   '@rollup/rollup-android-arm-eabi@4.18.0':
     optional: true
@@ -6747,149 +5189,10 @@ snapshots:
   '@scure/base@1.1.6': {}
 
   '@scure/bip32@1.4.0':
-=======
-    dev: true
-
-  /@rollup/rollup-android-arm-eabi@4.18.0:
-    resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.18.0:
-    resolution: {integrity: sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-darwin-arm64@4.18.0:
-    resolution: {integrity: sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.18.0:
-    resolution: {integrity: sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm-gnueabihf@4.18.0:
-    resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm-musleabihf@4.18.0:
-    resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-gnu@4.18.0:
-    resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-musl@4.18.0:
-    resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-powerpc64le-gnu@4.18.0:
-    resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.18.0:
-    resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-s390x-gnu@4.18.0:
-    resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-gnu@4.18.0:
-    resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.18.0:
-    resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-arm64-msvc@4.18.0:
-    resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-ia32-msvc@4.18.0:
-    resolution: {integrity: sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.18.0:
-    resolution: {integrity: sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@scure/base@1.1.6:
-    resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
-    dev: false
-
-  /@scure/bip32@1.4.0:
-    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.6
-<<<<<<< HEAD
 
   '@scure/bip39@1.3.0':
     dependencies:
@@ -6948,42 +5251,6 @@ snapshots:
   '@stablelib/bytes@1.0.1': {}
 
   '@stablelib/chacha20poly1305@1.0.1':
-=======
-    dev: false
-
-  /@scure/bip39@1.3.0:
-    resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
-    dependencies:
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
-    dev: false
-
-  /@sinclair/typebox@0.24.51:
-    resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
-    dev: true
-
-  /@sindresorhus/merge-streams@2.3.0:
-    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /@stablelib/aead@1.0.1:
-    resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
-    dev: false
-
-  /@stablelib/binary@1.0.1:
-    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
-    dependencies:
-      '@stablelib/int': 1.0.1
-    dev: false
-
-  /@stablelib/bytes@1.0.1:
-    resolution: {integrity: sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==}
-    dev: false
-
-  /@stablelib/chacha20poly1305@1.0.1:
-    resolution: {integrity: sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/aead': 1.0.1
       '@stablelib/binary': 1.0.1
@@ -6991,7 +5258,6 @@ snapshots:
       '@stablelib/constant-time': 1.0.1
       '@stablelib/poly1305': 1.0.1
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@stablelib/chacha@1.0.1':
     dependencies:
@@ -7001,60 +5267,24 @@ snapshots:
   '@stablelib/constant-time@1.0.1': {}
 
   '@stablelib/ed25519@1.0.3':
-=======
-    dev: false
-
-  /@stablelib/chacha@1.0.1:
-    resolution: {integrity: sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==}
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: false
-
-  /@stablelib/constant-time@1.0.1:
-    resolution: {integrity: sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==}
-    dev: false
-
-  /@stablelib/ed25519@1.0.3:
-    resolution: {integrity: sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/random': 1.0.2
       '@stablelib/sha512': 1.0.1
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@stablelib/hash@1.0.1': {}
 
   '@stablelib/hkdf@1.0.1':
-=======
-    dev: false
-
-  /@stablelib/hash@1.0.1:
-    resolution: {integrity: sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==}
-    dev: false
-
-  /@stablelib/hkdf@1.0.1:
-    resolution: {integrity: sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/hash': 1.0.1
       '@stablelib/hmac': 1.0.1
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@stablelib/hmac@1.0.1':
-=======
-    dev: false
-
-  /@stablelib/hmac@1.0.1:
-    resolution: {integrity: sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/constant-time': 1.0.1
       '@stablelib/hash': 1.0.1
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@stablelib/int@1.0.1': {}
 
@@ -7073,73 +5303,24 @@ snapshots:
       '@stablelib/wipe': 1.0.1
 
   '@stablelib/sha256@1.0.1':
-=======
-    dev: false
-
-  /@stablelib/int@1.0.1:
-    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
-    dev: false
-
-  /@stablelib/keyagreement@1.0.1:
-    resolution: {integrity: sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==}
-    dependencies:
-      '@stablelib/bytes': 1.0.1
-    dev: false
-
-  /@stablelib/poly1305@1.0.1:
-    resolution: {integrity: sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==}
-    dependencies:
-      '@stablelib/constant-time': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: false
-
-  /@stablelib/random@1.0.2:
-    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: false
-
-  /@stablelib/sha256@1.0.1:
-    resolution: {integrity: sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/binary': 1.0.1
       '@stablelib/hash': 1.0.1
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@stablelib/sha512@1.0.1':
-=======
-    dev: false
-
-  /@stablelib/sha512@1.0.1:
-    resolution: {integrity: sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/binary': 1.0.1
       '@stablelib/hash': 1.0.1
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@stablelib/wipe@1.0.1': {}
 
   '@stablelib/x25519@1.0.3':
-=======
-    dev: false
-
-  /@stablelib/wipe@1.0.1:
-    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
-    dev: false
-
-  /@stablelib/x25519@1.0.3:
-    resolution: {integrity: sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/keyagreement': 1.0.1
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
-<<<<<<< HEAD
 
   '@total-typescript/ts-reset@0.5.1': {}
 
@@ -7190,100 +5371,6 @@ snapshots:
       '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0(eslint@9.4.0)(typescript@5.4.5))(eslint@9.4.0)(typescript@5.4.5)':
-=======
-    dev: false
-
-  /@total-typescript/ts-reset@0.5.1:
-    resolution: {integrity: sha512-AqlrT8YA1o7Ff5wPfMOL0pvL+1X+sw60NN6CcOCqs658emD6RfiXhF7Gu9QcfKBH7ELY2nInLhKSCWVoNL70MQ==}
-    dev: true
-
-  /@types/eslint-config-prettier@6.11.3:
-    resolution: {integrity: sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==}
-    dev: true
-
-  /@types/eslint@8.56.10:
-    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
-    dependencies:
-      '@types/estree': 1.0.5
-      '@types/json-schema': 7.0.15
-    dev: true
-
-  /@types/estree@1.0.5:
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-    dev: true
-
-  /@types/glob@7.2.0:
-    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
-    dependencies:
-      '@types/minimatch': 5.1.2
-      '@types/node': 20.14.2
-    dev: true
-
-  /@types/graceful-fs@4.1.9:
-    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
-    dependencies:
-      '@types/node': 20.14.2
-    dev: true
-
-  /@types/istanbul-lib-coverage@2.0.6:
-    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
-    dev: true
-
-  /@types/istanbul-lib-report@3.0.3:
-    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.6
-    dev: true
-
-  /@types/istanbul-reports@3.0.4:
-    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
-    dependencies:
-      '@types/istanbul-lib-report': 3.0.3
-    dev: true
-
-  /@types/json-schema@7.0.15:
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-    dev: true
-
-  /@types/lodash@4.17.4:
-    resolution: {integrity: sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==}
-    dev: true
-
-  /@types/minimatch@5.1.2:
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
-    dev: true
-
-  /@types/node@20.14.2:
-    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-
-  /@types/prettier@2.7.3:
-    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
-    dev: true
-
-  /@types/yargs-parser@21.0.3:
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-    dev: true
-
-  /@types/yargs@17.0.32:
-    resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
-    dependencies:
-      '@types/yargs-parser': 21.0.3
-    dev: true
-
-  /@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0)(eslint@9.4.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@eslint-community/regexpp': 4.10.1
       '@typescript-eslint/parser': 7.12.0(eslint@9.4.0)(typescript@5.4.5)
@@ -7296,29 +5383,12 @@ snapshots:
       ignore: 5.3.1
       natural-compare: 1.4.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
-<<<<<<< HEAD
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/parser@7.12.0(eslint@9.4.0)(typescript@5.4.5)':
-=======
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser@7.12.0(eslint@9.4.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@typescript-eslint/scope-manager': 7.12.0
       '@typescript-eslint/types': 7.12.0
@@ -7326,7 +5396,6 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.12.0
       debug: 4.3.5
       eslint: 9.4.0
-<<<<<<< HEAD
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -7338,37 +5407,12 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.12.0
 
   '@typescript-eslint/type-utils@7.12.0(eslint@9.4.0)(typescript@5.4.5)':
-=======
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/scope-manager@7.12.0:
-    resolution: {integrity: sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    dependencies:
-      '@typescript-eslint/types': 7.12.0
-      '@typescript-eslint/visitor-keys': 7.12.0
-    dev: true
-
-  /@typescript-eslint/type-utils@7.12.0(eslint@9.4.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-lib96tyRtMhLxwauDWUp/uW3FMhLA6D0rJ8T7HmH7x23Gk1Gwwu8UZ94NMXBvOELn6flSPiBrCKlehkiXyaqwA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
       '@typescript-eslint/utils': 7.12.0(eslint@9.4.0)(typescript@5.4.5)
       debug: 4.3.5
       eslint: 9.4.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
-<<<<<<< HEAD
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -7377,26 +5421,6 @@ snapshots:
   '@typescript-eslint/types@7.12.0': {}
 
   '@typescript-eslint/typescript-estree@7.12.0(typescript@5.4.5)':
-=======
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/types@7.12.0:
-    resolution: {integrity: sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree@7.12.0(typescript@5.4.5):
-    resolution: {integrity: sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@typescript-eslint/types': 7.12.0
       '@typescript-eslint/visitor-keys': 7.12.0
@@ -7406,25 +5430,12 @@ snapshots:
       minimatch: 9.0.4
       semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
-<<<<<<< HEAD
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/utils@7.12.0(eslint@9.4.0)(typescript@5.4.5)':
-=======
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@7.12.0(eslint@9.4.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.4.0)
       '@typescript-eslint/scope-manager': 7.12.0
@@ -7434,7 +5445,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-<<<<<<< HEAD
 
   '@typescript-eslint/visitor-keys@7.12.0':
     dependencies:
@@ -7442,20 +5452,6 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@walletconnect/core@2.8.6':
-=======
-    dev: true
-
-  /@typescript-eslint/visitor-keys@7.12.0:
-    resolution: {integrity: sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    dependencies:
-      '@typescript-eslint/types': 7.12.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
-  /@walletconnect/core@2.8.6:
-    resolution: {integrity: sha512-rnSqm1KJLcww/v6+UH8JeibQkJ3EKgyUDPfEK0stSEkrIUIcXaFlq3Et8S+vgV8bPhI0MVUhAhFL5OJZ3t2ryg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-provider': 1.0.13
@@ -7490,15 +5486,8 @@ snapshots:
       - ioredis
       - uWebSockets.js
       - utf-8-validate
-<<<<<<< HEAD
 
   '@walletconnect/crypto@1.0.3':
-=======
-    dev: false
-
-  /@walletconnect/crypto@1.0.3:
-    resolution: {integrity: sha512-+2jdORD7XQs76I2Odgr3wwrtyuLUXD/kprNVsjWRhhhdO9Mt6WqVzOPu0/t7OHSmgal8k7SoBQzUc5hu/8zL/g==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/encoding': 1.0.2
       '@walletconnect/environment': 1.0.1
@@ -7506,20 +5495,12 @@ snapshots:
       aes-js: 3.1.2
       hash.js: 1.1.7
       tslib: 1.14.1
-<<<<<<< HEAD
 
   '@walletconnect/encoding@1.0.2':
-=======
-    dev: false
-
-  /@walletconnect/encoding@1.0.2:
-    resolution: {integrity: sha512-CrwSBrjqJ7rpGQcTL3kU+Ief+Bcuu9PH6JLOb+wM6NITX1GTxR/MfNwnQfhLKK6xpRAyj2/nM04OOH6wS8Imag==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       is-typedarray: 1.0.0
       tslib: 1.14.1
       typedarray-to-buffer: 3.1.5
-<<<<<<< HEAD
 
   '@walletconnect/environment@1.0.1':
     dependencies:
@@ -7531,43 +5512,16 @@ snapshots:
       tslib: 1.14.1
 
   '@walletconnect/heartbeat@1.2.1':
-=======
-    dev: false
-
-  /@walletconnect/environment@1.0.1:
-    resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/events@1.0.1:
-    resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
-    dependencies:
-      keyvaluestorage-interface: 1.0.0
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/heartbeat@1.2.1:
-    resolution: {integrity: sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/time': 1.0.2
       tslib: 1.14.1
-<<<<<<< HEAD
 
   '@walletconnect/jsonrpc-provider@1.0.13':
-=======
-    dev: false
-
-  /@walletconnect/jsonrpc-provider@1.0.13:
-    resolution: {integrity: sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
       tslib: 1.14.1
-<<<<<<< HEAD
 
   '@walletconnect/jsonrpc-types@1.0.3':
     dependencies:
@@ -7580,39 +5534,12 @@ snapshots:
       keyvaluestorage-interface: 1.0.0
 
   '@walletconnect/jsonrpc-utils@1.0.8':
-=======
-    dev: false
-
-  /@walletconnect/jsonrpc-types@1.0.3:
-    resolution: {integrity: sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==}
-    dependencies:
-      keyvaluestorage-interface: 1.0.0
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/jsonrpc-types@1.0.4:
-    resolution: {integrity: sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==}
-    dependencies:
-      events: 3.3.0
-      keyvaluestorage-interface: 1.0.0
-    dev: false
-
-  /@walletconnect/jsonrpc-utils@1.0.8:
-    resolution: {integrity: sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/environment': 1.0.1
       '@walletconnect/jsonrpc-types': 1.0.4
       tslib: 1.14.1
-<<<<<<< HEAD
 
   '@walletconnect/jsonrpc-ws-connection@1.0.14':
-=======
-    dev: false
-
-  /@walletconnect/jsonrpc-ws-connection@1.0.14:
-    resolution: {integrity: sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
@@ -7621,20 +5548,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-<<<<<<< HEAD
 
   '@walletconnect/keyvaluestorage@1.1.1':
-=======
-    dev: false
-
-  /@walletconnect/keyvaluestorage@1.1.1:
-    resolution: {integrity: sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==}
-    peerDependencies:
-      '@react-native-async-storage/async-storage': 1.x
-    peerDependenciesMeta:
-      '@react-native-async-storage/async-storage':
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/safe-json': 1.0.2
       idb-keyval: 6.2.1
@@ -7653,15 +5568,8 @@ snapshots:
       - '@vercel/kv'
       - ioredis
       - uWebSockets.js
-<<<<<<< HEAD
 
   '@walletconnect/legacy-client@2.0.0':
-=======
-    dev: false
-
-  /@walletconnect/legacy-client@2.0.0:
-    resolution: {integrity: sha512-v5L7rYk9loVnfvUf0mF+76bUPFaU5/Vh7mzL6/950CD/yoGdzYZ3Kj+L7mkC6HPMEGeQsBP1+sqBuiVGZ/aODA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/crypto': 1.0.3
       '@walletconnect/encoding': 1.0.2
@@ -7673,25 +5581,12 @@ snapshots:
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
       query-string: 6.14.1
-<<<<<<< HEAD
 
   '@walletconnect/legacy-types@2.0.0':
     dependencies:
       '@walletconnect/jsonrpc-types': 1.0.4
 
   '@walletconnect/legacy-utils@2.0.0':
-=======
-    dev: false
-
-  /@walletconnect/legacy-types@2.0.0:
-    resolution: {integrity: sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==}
-    dependencies:
-      '@walletconnect/jsonrpc-types': 1.0.4
-    dev: false
-
-  /@walletconnect/legacy-utils@2.0.0:
-    resolution: {integrity: sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/encoding': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.8
@@ -7701,7 +5596,6 @@ snapshots:
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
       query-string: 6.14.1
-<<<<<<< HEAD
 
   '@walletconnect/logger@2.1.2':
     dependencies:
@@ -7709,43 +5603,17 @@ snapshots:
       pino: 7.11.0
 
   '@walletconnect/randombytes@1.0.3':
-=======
-    dev: false
-
-  /@walletconnect/logger@2.1.2:
-    resolution: {integrity: sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==}
-    dependencies:
-      '@walletconnect/safe-json': 1.0.2
-      pino: 7.11.0
-    dev: false
-
-  /@walletconnect/randombytes@1.0.3:
-    resolution: {integrity: sha512-35lpzxcHFbTN3ABefC9W+uBpNZl1GC4Wpx0ed30gibfO/y9oLdy1NznbV96HARQKSBV9J9M/rrtIvf6a23jfYw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/encoding': 1.0.2
       '@walletconnect/environment': 1.0.1
       randombytes: 2.1.0
       tslib: 1.14.1
-<<<<<<< HEAD
 
   '@walletconnect/relay-api@1.0.10':
     dependencies:
       '@walletconnect/jsonrpc-types': 1.0.4
 
   '@walletconnect/relay-auth@1.0.4':
-=======
-    dev: false
-
-  /@walletconnect/relay-api@1.0.10:
-    resolution: {integrity: sha512-tqrdd4zU9VBNqUaXXQASaexklv6A54yEyQQEXYOCr+Jz8Ket0dmPBDyg19LVSNUN2cipAghQc45/KVmfFJ0cYw==}
-    dependencies:
-      '@walletconnect/jsonrpc-types': 1.0.4
-    dev: false
-
-  /@walletconnect/relay-auth@1.0.4:
-    resolution: {integrity: sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/ed25519': 1.0.3
       '@stablelib/random': 1.0.2
@@ -7753,25 +5621,12 @@ snapshots:
       '@walletconnect/time': 1.0.2
       tslib: 1.14.1
       uint8arrays: 3.1.1
-<<<<<<< HEAD
 
   '@walletconnect/safe-json@1.0.2':
     dependencies:
       tslib: 1.14.1
 
   '@walletconnect/sign-client@2.8.6':
-=======
-    dev: false
-
-  /@walletconnect/safe-json@1.0.2:
-    resolution: {integrity: sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/sign-client@2.8.6:
-    resolution: {integrity: sha512-rOFTKTHP7oJfXgYHX7+SdB8VbcsEE3ZFG/bMdmZboWaBim1mrY3vUyDdKrNr0VgI3AwBiEQezQDfKxBX0pMSQQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/core': 2.8.6
       '@walletconnect/events': 1.0.1
@@ -7799,25 +5654,12 @@ snapshots:
       - ioredis
       - uWebSockets.js
       - utf-8-validate
-<<<<<<< HEAD
 
   '@walletconnect/time@1.0.2':
     dependencies:
       tslib: 1.14.1
 
   '@walletconnect/types@2.8.6':
-=======
-    dev: false
-
-  /@walletconnect/time@1.0.2:
-    resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/types@2.8.6:
-    resolution: {integrity: sha512-Z/PFa3W1XdxeTcCtdR6lUsFgZfU/69wWJBPyclPwn7cu1+eriuCr6XZXQpJjib3flU+HnwHiXeUuqZaheehPxw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.1
@@ -7840,15 +5682,8 @@ snapshots:
       - '@vercel/kv'
       - ioredis
       - uWebSockets.js
-<<<<<<< HEAD
 
   '@walletconnect/utils@2.8.6':
-=======
-    dev: false
-
-  /@walletconnect/utils@2.8.6:
-    resolution: {integrity: sha512-wcy6e5+COYo7tfNnW8YqidnATdJDIW6vDiWWE7A1F78Sl/VflkaevB9cIgyn8eLdxC1SxXgGoeC2oLP90nnHJg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
       '@stablelib/hkdf': 1.0.1
@@ -7879,7 +5714,6 @@ snapshots:
       - '@vercel/kv'
       - ioredis
       - uWebSockets.js
-<<<<<<< HEAD
 
   '@walletconnect/window-getters@1.0.1':
     dependencies:
@@ -7899,62 +5733,17 @@ snapshots:
   aes-js@3.1.2: {}
 
   agent-base@7.1.1:
-=======
-    dev: false
-
-  /@walletconnect/window-getters@1.0.1:
-    resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/window-metadata@1.0.1:
-    resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
-    dependencies:
-      '@walletconnect/window-getters': 1.0.1
-      tslib: 1.14.1
-    dev: false
-
-  /acorn-jsx@5.3.2(acorn@8.11.3):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.11.3
-    dev: true
-
-  /acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  /aes-js@3.1.2:
-    resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
-    dev: false
-
-  /agent-base@7.1.1:
-    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
-    engines: {node: '>= 14'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   ajv@6.12.6:
-=======
-    dev: true
-
-  /ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-<<<<<<< HEAD
 
   ansi-colors@4.1.3: {}
 
@@ -7987,86 +5776,10 @@ snapshots:
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
-=======
-    dev: true
-
-  /ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /ansi-escapes@2.0.0:
-    resolution: {integrity: sha512-tH/fSoQp4DrEodDK3QpdiWiZTSe7sBJ9eOqcQBZ0o9HTM+5M/viSEn+sPMoTuPjQQ8n++w3QJoPEjt8LVPcrCg==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /ansi-escapes@3.2.0:
-    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /ansi-regex@6.0.1:
-    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: 1.9.3
-    dev: true
-
-  /ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-    dependencies:
-      color-convert: 2.0.1
-    dev: true
-
-  /ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-    dev: true
-
-  /anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-<<<<<<< HEAD
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -8083,35 +5796,6 @@ snapshots:
       is-array-buffer: 3.0.4
 
   array-includes@3.1.8:
-=======
-  /argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-    dependencies:
-      sprintf-js: 1.0.3
-    dev: true
-
-  /argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
-
-  /aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
-    dependencies:
-      dequal: 2.0.3
-    dev: true
-
-  /array-buffer-byte-length@1.0.1:
-    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.7
-      is-array-buffer: 3.0.4
-    dev: true
-
-  /array-includes@3.1.8:
-    resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -8119,23 +5803,10 @@ snapshots:
       es-object-atoms: 1.0.0
       get-intrinsic: 1.2.4
       is-string: 1.0.7
-<<<<<<< HEAD
 
   array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
-=======
-    dev: true
-
-  /array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /array.prototype.findlast@1.2.5:
-    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -8143,76 +5814,37 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.0.0
       es-shim-unscopables: 1.0.2
-<<<<<<< HEAD
 
   array.prototype.flat@1.3.2:
-=======
-    dev: true
-
-  /array.prototype.flat@1.3.2:
-    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-shim-unscopables: 1.0.2
-<<<<<<< HEAD
 
   array.prototype.flatmap@1.3.2:
-=======
-    dev: true
-
-  /array.prototype.flatmap@1.3.2:
-    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-shim-unscopables: 1.0.2
-<<<<<<< HEAD
 
   array.prototype.toreversed@1.1.2:
-=======
-    dev: true
-
-  /array.prototype.toreversed@1.1.2:
-    resolution: {integrity: sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-shim-unscopables: 1.0.2
-<<<<<<< HEAD
 
   array.prototype.tosorted@1.1.4:
-=======
-    dev: true
-
-  /array.prototype.tosorted@1.1.4:
-    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-errors: 1.3.0
       es-shim-unscopables: 1.0.2
-<<<<<<< HEAD
 
   arraybuffer.prototype.slice@1.0.3:
-=======
-    dev: true
-
-  /arraybuffer.prototype.slice@1.0.3:
-    resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       array-buffer-byte-length: 1.0.1
       call-bind: 1.0.7
@@ -8222,7 +5854,6 @@ snapshots:
       get-intrinsic: 1.2.4
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
-<<<<<<< HEAD
 
   ast-stringify@0.1.0:
     dependencies:
@@ -8245,50 +5876,6 @@ snapshots:
       dequal: 2.0.3
 
   babel-plugin-istanbul@6.1.1:
-=======
-    dev: true
-
-  /ast-stringify@0.1.0:
-    resolution: {integrity: sha512-J1PgFYV3RG6r37+M6ySZJH406hR82okwGvFM9hLXpOvdx4WC4GEW8/qiw6pi1hKTrqcRvoHP8a7mp87egYr6iA==}
-    dependencies:
-      '@babel/runtime': 7.24.7
-    dev: true
-
-  /ast-types-flow@0.0.8:
-    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
-    dev: true
-
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
-
-  /atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
-    dev: false
-
-  /available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      possible-typed-array-names: 1.0.0
-    dev: true
-
-  /axe-core@4.7.0:
-    resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /axobject-query@3.2.1:
-    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
-    dependencies:
-      dequal: 2.0.3
-    dev: true
-
-  /babel-plugin-istanbul@6.1.1:
-    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
-    engines: {node: '>=8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/helper-plugin-utils': 7.24.7
       '@istanbuljs/load-nyc-config': 1.1.0
@@ -8297,17 +5884,8 @@ snapshots:
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.18.10):
-=======
-    dev: true
-
-  /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/compat-data': 7.24.7
       '@babel/core': 7.18.10
@@ -8315,40 +5893,21 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.18.10):
-=======
-    dev: true
-
-  /babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.18.10):
-    resolution: {integrity: sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.18.10)
       core-js-compat: 3.37.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.18.10):
-=======
-    dev: true
-
-  /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.18.10):
-    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.18.10)
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   balanced-match@1.0.2: {}
 
@@ -8372,47 +5931,11 @@ snapshots:
       fill-range: 7.1.1
 
   browserslist@4.23.0:
-=======
-    dev: true
-
-  /balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
-
-  /binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
-  /brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-    dev: true
-
-  /brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-    dependencies:
-      balanced-match: 1.0.2
-    dev: true
-
-  /braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
-    dependencies:
-      fill-range: 7.1.1
-
-  /browserslist@4.23.0:
-    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       caniuse-lite: 1.0.30001629
       electron-to-chromium: 1.4.795
       node-releases: 2.0.14
       update-browserslist-db: 1.0.16(browserslist@4.23.0)
-<<<<<<< HEAD
 
   bser@2.1.1:
     dependencies:
@@ -8426,41 +5949,12 @@ snapshots:
   cac@6.7.14: {}
 
   call-bind@1.0.7:
-=======
-    dev: true
-
-  /bser@2.1.1:
-    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
-    dependencies:
-      node-int64: 0.4.0
-    dev: true
-
-  /bundle-require@4.2.1(esbuild@0.21.4):
-    resolution: {integrity: sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.17'
-    dependencies:
-      esbuild: 0.21.4
-      load-tsconfig: 0.2.5
-    dev: true
-
-  /cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /call-bind@1.0.7:
-    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
-<<<<<<< HEAD
 
   call-me-maybe@1.0.2: {}
 
@@ -8477,64 +5971,18 @@ snapshots:
       chalk: 5.3.0
 
   chalk@1.1.3:
-=======
-    dev: true
-
-  /call-me-maybe@1.0.2:
-    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
-    dev: true
-
-  /callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /caniuse-lite@1.0.30001629:
-    resolution: {integrity: sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==}
-    dev: true
-
-  /case@1.6.3:
-    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
-    engines: {node: '>= 0.8.0'}
-    dev: true
-
-  /chalk-template@1.1.0:
-    resolution: {integrity: sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==}
-    engines: {node: '>=14.16'}
-    dependencies:
-      chalk: 5.3.0
-    dev: true
-
-  /chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-styles: 2.2.1
       escape-string-regexp: 1.0.5
       has-ansi: 2.0.0
       strip-ansi: 3.0.1
       supports-color: 2.0.0
-<<<<<<< HEAD
 
   chalk@2.4.2:
-=======
-    dev: true
-
-  /chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-<<<<<<< HEAD
 
   chalk@4.1.2:
     dependencies:
@@ -8548,34 +5996,6 @@ snapshots:
   chardet@0.7.0: {}
 
   chokidar@3.6.0:
-=======
-    dev: true
-
-  /chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-    dev: true
-
-  /chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
-
-  /chardet@0.4.2:
-    resolution: {integrity: sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==}
-    dev: true
-
-  /chardet@0.7.0:
-    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: true
-
-  /chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       anymatch: 3.1.3
       braces: 3.0.3
@@ -8587,7 +6007,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-<<<<<<< HEAD
   ci-info@3.9.0: {}
 
   citty@0.1.6:
@@ -8595,29 +6014,12 @@ snapshots:
       consola: 3.2.3
 
   cli-color@2.0.4:
-=======
-  /ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
-    dependencies:
-      consola: 3.2.3
-    dev: false
-
-  /cli-color@2.0.4:
-    resolution: {integrity: sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==}
-    engines: {node: '>=0.10'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       es6-iterator: 2.0.3
       memoizee: 0.4.17
       timers-ext: 0.1.8
-<<<<<<< HEAD
 
   cli-cursor@2.1.0:
     dependencies:
@@ -8632,41 +6034,10 @@ snapshots:
   cli-width@2.2.1: {}
 
   clipboardy@4.0.0:
-=======
-    dev: true
-
-  /cli-cursor@2.1.0:
-    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
-    engines: {node: '>=4'}
-    dependencies:
-      restore-cursor: 2.0.0
-    dev: true
-
-  /cli-cursor@4.0.0:
-    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      restore-cursor: 4.0.0
-    dev: true
-
-  /cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /cli-width@2.2.1:
-    resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
-    dev: true
-
-  /clipboardy@4.0.0:
-    resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
-    engines: {node: '>=18'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       execa: 8.0.1
       is-wsl: 3.1.0
       is64bit: 2.0.0
-<<<<<<< HEAD
 
   color-convert@1.9.3:
     dependencies:
@@ -8717,112 +6088,20 @@ snapshots:
       lodash-es: 4.17.21
 
   cosmiconfig@9.0.0(typescript@5.4.5):
-=======
-    dev: false
-
-  /color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-    dependencies:
-      color-name: 1.1.3
-    dev: true
-
-  /color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-    dependencies:
-      color-name: 1.1.4
-    dev: true
-
-  /color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: true
-
-  /color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
-
-  /colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
-    engines: {node: '>=0.1.90'}
-    dev: true
-
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: true
-
-  /commander@12.0.0:
-    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-    dev: true
-
-  /confbox@0.1.7:
-    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
-    dev: false
-
-  /consola@3.2.3:
-    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    dev: false
-
-  /convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: true
-
-  /cookie-es@1.1.0:
-    resolution: {integrity: sha512-L2rLOcK0wzWSfSDA33YR+PUHDG10a8px7rUHKWbGLP4YfbsMed2KFUw5fczvDPbT98DDe3LEzviswl810apTEw==}
-    dev: false
-
-  /core-js-compat@3.37.1:
-    resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
-    dependencies:
-      browserslist: 4.23.0
-    dev: true
-
-  /cosmiconfig@9.0.0(typescript@5.4.5):
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-<<<<<<< HEAD
     optionalDependencies:
       typescript: 5.4.5
 
   cross-spawn@7.0.3:
-=======
-      typescript: 5.4.5
-    dev: true
-
-  /cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
-<<<<<<< HEAD
   crossws@0.2.4: {}
 
   cssstyle@4.0.1:
@@ -8844,85 +6123,22 @@ snapshots:
       whatwg-url: 14.0.0
 
   data-view-buffer@1.0.1:
-=======
-  /crossws@0.2.4:
-    resolution: {integrity: sha512-DAxroI2uSOgUKLz00NX6A8U/8EE3SZHmIND+10jkVSaypvyt57J5JEOxAQOL6lQxyzi/wZbTIwssU1uy69h5Vg==}
-    peerDependencies:
-      uWebSockets.js: '*'
-    peerDependenciesMeta:
-      uWebSockets.js:
-        optional: true
-    dev: false
-
-  /cssstyle@4.0.1:
-    resolution: {integrity: sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      rrweb-cssom: 0.6.0
-    dev: true
-
-  /d@1.0.2:
-    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
-    engines: {node: '>=0.12'}
-    dependencies:
-      es5-ext: 0.10.64
-      type: 2.7.3
-    dev: true
-
-  /damerau-levenshtein@1.0.8:
-    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
-    dev: true
-
-  /dargs@7.0.0:
-    resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /data-urls@5.0.0:
-    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
-    engines: {node: '>=18'}
-    dependencies:
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 14.0.0
-    dev: true
-
-  /data-view-buffer@1.0.1:
-    resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-<<<<<<< HEAD
 
   data-view-byte-length@1.0.1:
-=======
-    dev: true
-
-  /data-view-byte-length@1.0.1:
-    resolution: {integrity: sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-<<<<<<< HEAD
 
   data-view-byte-offset@1.0.0:
-=======
-    dev: true
-
-  /data-view-byte-offset@1.0.0:
-    resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-<<<<<<< HEAD
 
   debug@4.3.5:
     dependencies:
@@ -8937,62 +6153,16 @@ snapshots:
   deepmerge@4.2.2: {}
 
   define-data-property@1.1.4:
-=======
-    dev: true
-
-  /debug@4.3.5:
-    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: true
-
-  /decimal.js@10.4.3:
-    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
-    dev: true
-
-  /decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
-    dev: false
-
-  /deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-    dev: true
-
-  /deepmerge@4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
-<<<<<<< HEAD
 
   define-properties@1.2.1:
-=======
-    dev: true
-
-  /define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-<<<<<<< HEAD
 
   defu@6.1.4: {}
 
@@ -9017,64 +6187,11 @@ snapshots:
   dotty@0.1.2: {}
 
   duplexify@4.1.3:
-=======
-    dev: true
-
-  /defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
-    dev: false
-
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: true
-
-  /dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /destr@2.0.3:
-    resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
-    dev: false
-
-  /detect-browser@5.3.0:
-    resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==}
-    dev: false
-
-  /detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-    dev: false
-
-  /dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-type: 4.0.0
-    dev: true
-
-  /doctrine@2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      esutils: 2.0.3
-    dev: true
-
-  /dotty@0.1.2:
-    resolution: {integrity: sha512-V0EWmKeH3DEhMwAZ+8ZB2Ao4OK6p++Z0hsDtZq3N0+0ZMVqkzrcEGROvOnZpLnvBg5PTNG23JEDLAm64gPaotQ==}
-    dev: true
-
-  /duplexify@4.1.3:
-    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       end-of-stream: 1.4.4
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
-<<<<<<< HEAD
 
   eastasianwidth@0.2.0: {}
 
@@ -9106,67 +6223,6 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-abstract@1.23.3:
-=======
-    dev: false
-
-  /eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
-
-  /effect@3.0.3:
-    resolution: {integrity: sha512-mgG+FoWrM4sny8OxDFWCpq+6LwGf9cK/JztVhxZQeZM9ZMXY+lKbdMEQmemNYce0QVAz2+YqUKwhKzOidwbZzg==}
-    dev: true
-
-  /electron-to-chromium@1.4.795:
-    resolution: {integrity: sha512-hHo4lK/8wb4NUa+NJYSFyJ0xedNHiR6ylilDtb8NUW9d4dmBFmGiecYEKCEbti1wTNzbKXLfl4hPWEkAFbHYlw==}
-    dev: true
-
-  /emoji-regex@10.3.0:
-    resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
-    dev: true
-
-  /emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
-
-  /emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
-
-  /end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-    dependencies:
-      once: 1.4.0
-    dev: false
-
-  /enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      ansi-colors: 4.1.3
-      strip-ansi: 6.0.1
-    dev: true
-
-  /entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-    dev: true
-
-  /env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
-    dependencies:
-      is-arrayish: 0.2.1
-    dev: true
-
-  /es-abstract@1.23.3:
-    resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       array-buffer-byte-length: 1.0.1
       arraybuffer.prototype.slice: 1.0.3
@@ -9214,7 +6270,6 @@ snapshots:
       typed-array-length: 1.0.6
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.15
-<<<<<<< HEAD
 
   es-define-property@1.0.0:
     dependencies:
@@ -9223,25 +6278,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-iterator-helpers@1.0.19:
-=======
-    dev: true
-
-  /es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: 1.2.4
-    dev: true
-
-  /es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /es-iterator-helpers@1.0.19:
-    resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -9257,85 +6293,39 @@ snapshots:
       internal-slot: 1.0.7
       iterator.prototype: 1.1.2
       safe-array-concat: 1.1.2
-<<<<<<< HEAD
 
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
 
   es-set-tostringtag@2.0.3:
-=======
-    dev: true
-
-  /es-object-atoms@1.0.0:
-    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      es-errors: 1.3.0
-    dev: true
-
-  /es-set-tostringtag@2.0.3:
-    resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       get-intrinsic: 1.2.4
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-<<<<<<< HEAD
 
   es-shim-unscopables@1.0.2:
     dependencies:
       hasown: 2.0.2
 
   es-to-primitive@1.2.1:
-=======
-    dev: true
-
-  /es-shim-unscopables@1.0.2:
-    resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
-    dependencies:
-      hasown: 2.0.2
-    dev: true
-
-  /es-to-primitive@1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
-<<<<<<< HEAD
 
   es5-ext@0.10.64:
-=======
-    dev: true
-
-  /es5-ext@0.10.64:
-    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
-    engines: {node: '>=0.10'}
-    requiresBuild: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.4
       esniff: 2.0.1
       next-tick: 1.1.0
-<<<<<<< HEAD
 
   es6-iterator@2.0.3:
-=======
-    dev: true
-
-  /es6-iterator@2.0.3:
-    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       es6-symbol: 3.1.4
-<<<<<<< HEAD
 
   es6-symbol@3.1.4:
     dependencies:
@@ -9343,37 +6333,13 @@ snapshots:
       ext: 1.7.0
 
   es6-weak-map@2.0.3:
-=======
-    dev: true
-
-  /es6-symbol@3.1.4:
-    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
-    engines: {node: '>=0.12'}
-    dependencies:
-      d: 1.0.2
-      ext: 1.7.0
-    dev: true
-
-  /es6-weak-map@2.0.3:
-    resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       es6-iterator: 2.0.3
       es6-symbol: 3.1.4
-<<<<<<< HEAD
 
   esbuild@0.21.4:
-=======
-    dev: true
-
-  /esbuild@0.21.4:
-    resolution: {integrity: sha512-sFMcNNrj+Q0ZDolrp5pDhH0nRPN9hLIM3fRPwgbLYJeSHHgnXSnbV3xYgSVuOeLWH9c73VwmEverVzupIv5xuA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.4
       '@esbuild/android-arm': 0.21.4
@@ -9398,7 +6364,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.4
       '@esbuild/win32-ia32': 0.21.4
       '@esbuild/win32-x64': 0.21.4
-<<<<<<< HEAD
 
   escalade@3.1.2: {}
 
@@ -9411,55 +6376,12 @@ snapshots:
       eslint: 9.4.0
 
   eslint-plugin-eslint-comments@3.2.0(eslint@9.4.0):
-=======
-    dev: true
-
-  /escalade@3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  /escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /eslint-config-prettier@9.1.0(eslint@9.4.0):
-    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 9.4.0
-    dev: true
-
-  /eslint-plugin-eslint-comments@3.2.0(eslint@9.4.0):
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 9.4.0
       ignore: 5.3.1
-<<<<<<< HEAD
 
   eslint-plugin-jsx-a11y@6.8.0(eslint@9.4.0):
-=======
-    dev: true
-
-  /eslint-plugin-jsx-a11y@6.8.0(eslint@9.4.0):
-    resolution: {integrity: sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/runtime': 7.24.7
       aria-query: 5.3.0
@@ -9478,7 +6400,6 @@ snapshots:
       minimatch: 3.1.2
       object.entries: 1.1.8
       object.fromentries: 2.0.8
-<<<<<<< HEAD
 
   eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.3.1):
     dependencies:
@@ -9499,54 +6420,6 @@ snapshots:
       eslint: 9.4.0
 
   eslint-plugin-react@7.34.2(eslint@9.4.0):
-=======
-    dev: true
-
-  /eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0)(eslint@9.4.0)(prettier@3.3.1):
-    resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
-    peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      '@types/eslint': 8.56.10
-      eslint: 9.4.0
-      eslint-config-prettier: 9.1.0(eslint@9.4.0)
-      prettier: 3.3.1
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.8.8
-    dev: true
-
-  /eslint-plugin-react-hooks@4.6.2(eslint@9.4.0):
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 9.4.0
-    dev: true
-
-  /eslint-plugin-react-refresh@0.4.7(eslint@9.4.0):
-    resolution: {integrity: sha512-yrj+KInFmwuQS2UQcg1SF83ha1tuHC1jMQbRNyuWtlEzzKRDgAl7L4Yp4NlDUZTZNlWvHEzOtJhMi40R7JxcSw==}
-    peerDependencies:
-      eslint: '>=7'
-    dependencies:
-      eslint: 9.4.0
-    dev: true
-
-  /eslint-plugin-react@7.34.2(eslint@9.4.0):
-    resolution: {integrity: sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -9567,7 +6440,6 @@ snapshots:
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
-<<<<<<< HEAD
 
   eslint-scope@8.0.1:
     dependencies:
@@ -9579,32 +6451,6 @@ snapshots:
   eslint-visitor-keys@4.0.0: {}
 
   eslint@9.4.0:
-=======
-    dev: true
-
-  /eslint-scope@8.0.1:
-    resolution: {integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-    dev: true
-
-  /eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /eslint-visitor-keys@4.0.0:
-    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
-  /eslint@9.4.0:
-    resolution: {integrity: sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.4.0)
       '@eslint-community/regexpp': 4.10.1
@@ -9642,36 +6488,19 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   esniff@2.0.1:
-=======
-    dev: true
-
-  /esniff@2.0.1:
-    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
-    engines: {node: '>=0.10'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       event-emitter: 0.3.5
       type: 2.7.3
-<<<<<<< HEAD
 
   espree@10.0.1:
-=======
-    dev: true
-
-  /espree@10.0.1:
-    resolution: {integrity: sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       acorn: 8.11.3
       acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 4.0.0
-<<<<<<< HEAD
 
   esprima@4.0.1: {}
 
@@ -9695,55 +6524,6 @@ snapshots:
   events@3.3.0: {}
 
   execa@5.1.1:
-=======
-    dev: true
-
-  /esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: true
-
-  /esquery@1.5.0:
-    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      estraverse: 5.3.0
-    dev: true
-
-  /esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-    dependencies:
-      estraverse: 5.3.0
-    dev: true
-
-  /estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-    dev: true
-
-  /esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /event-emitter@0.3.5:
-    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
-    dependencies:
-      d: 1.0.2
-      es5-ext: 0.10.64
-    dev: true
-
-  /events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-    dev: false
-
-  /execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 6.0.1
@@ -9754,16 +6534,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-<<<<<<< HEAD
 
   execa@8.0.1:
-=======
-    dev: true
-
-  /execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 8.0.1
@@ -9774,45 +6546,22 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
-<<<<<<< HEAD
 
   ext@1.7.0:
     dependencies:
       type: 2.7.3
 
   external-editor@2.2.0:
-=======
-    dev: false
-
-  /ext@1.7.0:
-    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
-    dependencies:
-      type: 2.7.3
-    dev: true
-
-  /external-editor@2.2.0:
-    resolution: {integrity: sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==}
-    engines: {node: '>=0.12'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       chardet: 0.4.2
       iconv-lite: 0.4.24
       tmp: 0.0.33
-<<<<<<< HEAD
 
   external-editor@3.1.0:
-=======
-    dev: true
-
-  /external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
-    engines: {node: '>=4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-<<<<<<< HEAD
 
   fast-check@3.17.2:
     dependencies:
@@ -9823,35 +6572,12 @@ snapshots:
   fast-diff@1.3.0: {}
 
   fast-glob@3.3.2:
-=======
-    dev: true
-
-  /fast-check@3.17.2:
-    resolution: {integrity: sha512-+3DPTxtxABLgmmVpYxrash3DHoq0cMa1jjLYNp3qqokKKhqVEaS4lbnaDKqWU5Dd6C2pEudPPBAEEQ9nUou9OQ==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      pure-rand: 6.1.0
-    dev: true
-
-  /fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
-
-  /fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-    dev: true
-
-  /fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
-    engines: {node: '>=8.6.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.7
-<<<<<<< HEAD
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -9908,110 +6634,10 @@ snapshots:
       signal-exit: 4.1.0
 
   form-data@4.0.0:
-=======
-    dev: true
-
-  /fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-    dev: true
-
-  /fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-    dev: true
-
-  /fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /fastq@1.17.1:
-    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
-    dependencies:
-      reusify: 1.0.4
-    dev: true
-
-  /fb-watchman@2.0.2:
-    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
-    dependencies:
-      bser: 2.1.1
-    dev: true
-
-  /figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
-    engines: {node: '>=4'}
-    dependencies:
-      escape-string-regexp: 1.0.5
-    dev: true
-
-  /file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      flat-cache: 4.0.1
-    dev: true
-
-  /fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-    dependencies:
-      to-regex-range: 5.0.1
-
-  /filter-obj@1.1.0:
-    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  /find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
-    dependencies:
-      locate-path: 5.0.0
-      path-exists: 4.0.0
-    dev: true
-
-  /find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-    dev: true
-
-  /flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
-    dependencies:
-      flatted: 3.3.1
-      keyv: 4.5.4
-    dev: true
-
-  /flatted@3.3.1:
-    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
-    dev: true
-
-  /for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-    dependencies:
-      is-callable: 1.2.7
-    dev: true
-
-  /foreground-child@3.1.1:
-    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
-    engines: {node: '>=14'}
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 4.1.0
-    dev: true
-
-  /form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-<<<<<<< HEAD
 
   fs.realpath@1.0.0: {}
 
@@ -10021,34 +6647,11 @@ snapshots:
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.6:
-=======
-    dev: true
-
-  /fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
-
-  /fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
-
-  /function.prototype.name@1.1.6:
-    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       functions-have-names: 1.2.3
-<<<<<<< HEAD
 
   functions-have-names@1.2.3: {}
 
@@ -10059,39 +6662,12 @@ snapshots:
   get-east-asian-width@1.2.0: {}
 
   get-intrinsic@1.2.4:
-=======
-    dev: true
-
-  /functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-    dev: true
-
-  /fuzzy@0.1.3:
-    resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
-    engines: {node: '>= 0.6.0'}
-    dev: true
-
-  /gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /get-east-asian-width@1.2.0:
-    resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /get-intrinsic@1.2.4:
-    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
-<<<<<<< HEAD
 
   get-package-type@0.1.0: {}
 
@@ -10104,42 +6680,10 @@ snapshots:
   get-stream@8.0.1: {}
 
   get-symbol-description@1.0.2:
-=======
-    dev: true
-
-  /get-package-type@0.1.0:
-    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
-    engines: {node: '>=8.0.0'}
-    dev: true
-
-  /get-port-please@3.1.2:
-    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
-    dev: false
-
-  /get-stdin@8.0.0:
-    resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-    dev: false
-
-  /get-symbol-description@1.0.2:
-    resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
-<<<<<<< HEAD
 
   glob-parent@5.1.2:
     dependencies:
@@ -10155,53 +6699,14 @@ snapshots:
       glob: 7.2.3
 
   glob@10.4.1:
-=======
-    dev: true
-
-  /glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-    dependencies:
-      is-glob: 4.0.3
-
-  /glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      is-glob: 4.0.3
-    dev: true
-
-  /glob-promise@4.2.2(glob@7.2.3):
-    resolution: {integrity: sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      glob: ^7.1.6
-    dependencies:
-      '@types/glob': 7.2.0
-      glob: 7.2.3
-    dev: true
-
-  /glob@10.4.1:
-    resolution: {integrity: sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==}
-    engines: {node: '>=16 || 14 >=14.18'}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 3.4.0
       minimatch: 9.0.4
       minipass: 7.1.2
       path-scurry: 1.11.1
-<<<<<<< HEAD
 
   glob@7.2.3:
-=======
-    dev: true
-
-  /glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -10209,24 +6714,14 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-<<<<<<< HEAD
 
   glob@8.0.3:
-=======
-    dev: true
-
-  /glob@8.0.3:
-    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
-    engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
       minimatch: 5.1.6
       once: 1.4.0
-<<<<<<< HEAD
 
   globals@11.12.0: {}
 
@@ -10240,36 +6735,6 @@ snapshots:
       gopd: 1.0.1
 
   globby@11.1.0:
-=======
-    dev: true
-
-  /globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /globals@15.4.0:
-    resolution: {integrity: sha512-unnwvMZpv0eDUyjNyh9DH/yxUaRYrEjW/qK4QcdrHg3oO11igUQrCSgODHEqxlKg8v2CD2Sd7UkqqEBoz5U7TQ==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.0.1
-    dev: true
-
-  /globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
@@ -10277,16 +6742,8 @@ snapshots:
       ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
-<<<<<<< HEAD
 
   globby@14.0.1:
-=======
-    dev: true
-
-  /globby@14.0.1:
-    resolution: {integrity: sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==}
-    engines: {node: '>=18'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
       fast-glob: 3.3.2
@@ -10294,7 +6751,6 @@ snapshots:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
-<<<<<<< HEAD
 
   gopd@1.0.1:
     dependencies:
@@ -10305,26 +6761,6 @@ snapshots:
   graphemer@1.4.0: {}
 
   h3@1.11.1:
-=======
-    dev: true
-
-  /gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
-    dependencies:
-      get-intrinsic: 1.2.4
-    dev: true
-
-  /graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
-
-  /graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-    dev: true
-
-  /h3@1.11.1:
-    resolution: {integrity: sha512-AbaH6IDnZN6nmbnJOH72y3c5Wwh9P97soSVdGSBbcDACRdkC0FEWf25pzx4f/NuOCK6quHmW18yF2Wx+G4Zi1A==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       cookie-es: 1.1.0
       crossws: 0.2.4
@@ -10338,7 +6774,6 @@ snapshots:
       unenv: 1.9.0
     transitivePeerDependencies:
       - uWebSockets.js
-<<<<<<< HEAD
 
   has-ansi@2.0.0:
     dependencies:
@@ -10380,113 +6815,20 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   http-proxy-agent@7.0.2:
-=======
-    dev: false
-
-  /has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: true
-
-  /has-bigints@1.0.2:
-    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
-    dev: true
-
-  /has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-    dependencies:
-      es-define-property: 1.0.0
-    dev: true
-
-  /has-proto@1.0.3:
-    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: 1.0.3
-    dev: true
-
-  /hash.js@1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-    dev: false
-
-  /hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      function-bind: 1.1.2
-    dev: true
-
-  /hosted-git-info@7.0.2:
-    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-    dependencies:
-      lru-cache: 10.2.2
-    dev: true
-
-  /html-encoding-sniffer@4.0.0:
-    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      whatwg-encoding: 3.1.1
-    dev: true
-
-  /http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       agent-base: 7.1.1
       debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   http-shutdown@1.2.2: {}
 
   https-proxy-agent@7.0.4:
-=======
-    dev: true
-
-  /http-shutdown@1.2.2:
-    resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
-    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
-    dev: false
-
-  /https-proxy-agent@7.0.4:
-    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
-    engines: {node: '>= 14'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       agent-base: 7.1.1
       debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   human-signals@2.1.0: {}
 
@@ -10521,73 +6863,6 @@ snapshots:
   inherits@2.0.4: {}
 
   inquirer-autocomplete-prompt@0.11.1:
-=======
-    dev: true
-
-  /human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-    dev: true
-
-  /human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-    dev: false
-
-  /iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: true
-
-  /iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: true
-
-  /idb-keyval@6.2.1:
-    resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
-    dev: false
-
-  /ignore@5.3.1:
-    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
-    engines: {node: '>= 4'}
-    dev: true
-
-  /import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
-    engines: {node: '>=6'}
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-    dev: true
-
-  /imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-    dev: true
-
-  /inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    dev: true
-
-  /inherits@2.0.3:
-    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
-    dev: true
-
-  /inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  /inquirer-autocomplete-prompt@0.11.1:
-    resolution: {integrity: sha512-VM4eNiyRD4CeUc2cyKni+F8qgHwL9WC4LdOr+mEC85qP/QNsDV+ysVqUrJYhw1TmDQu1QVhc8hbaL7wfk8SJxw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-escapes: 2.0.0
       chalk: 1.1.3
@@ -10596,15 +6871,8 @@ snapshots:
       lodash: 4.17.21
       run-async: 2.4.1
       util: 0.10.4
-<<<<<<< HEAD
 
   inquirer@3.1.1:
-=======
-    dev: true
-
-  /inquirer@3.1.1:
-    resolution: {integrity: sha512-H50sHQwgvvaTBd3HpKMVtL/u6LoHDvYym51gd7bGQe/+9HkCE+J0/3N5FJLfd6O6oz44hHewC2Pc2LodzWVafQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-escapes: 2.0.0
       chalk: 1.1.3
@@ -10620,16 +6888,8 @@ snapshots:
       string-width: 2.1.1
       strip-ansi: 3.0.1
       through: 2.3.8
-<<<<<<< HEAD
 
   inquirer@6.5.2:
-=======
-    dev: true
-
-  /inquirer@6.5.2:
-    resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
-    engines: {node: '>=6.0.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-escapes: 3.2.0
       chalk: 2.4.2
@@ -10644,34 +6904,18 @@ snapshots:
       string-width: 2.1.1
       strip-ansi: 5.2.0
       through: 2.3.8
-<<<<<<< HEAD
 
   inquirerer@0.1.3:
-=======
-    dev: true
-
-  /inquirerer@0.1.3:
-    resolution: {integrity: sha512-yGgLUOqPxTsINBjZNZeLi3cv2zgxXtw9feaAOSJf2j6AqIT5Uxs5ZOqOrfAf+xP65Sicla1FD3iDxa3D6TsCAQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       colors: 1.4.0
       inquirer: 6.5.2
       inquirer-autocomplete-prompt: 0.11.1
-<<<<<<< HEAD
 
   internal-slot@1.0.7:
-=======
-    dev: true
-
-  /internal-slot@1.0.7:
-    resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
-<<<<<<< HEAD
 
   interpret@1.4.0: {}
 
@@ -10816,282 +7060,6 @@ snapshots:
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
-=======
-    dev: true
-
-  /interpret@1.4.0:
-    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
-    engines: {node: '>= 0.10'}
-    dev: true
-
-  /iron-webcrypto@1.2.1:
-    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
-    dev: false
-
-  /is-array-buffer@3.0.4:
-    resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.7
-      get-intrinsic: 1.2.4
-    dev: true
-
-  /is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
-
-  /is-async-function@2.0.0:
-    resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-bigint@1.0.4:
-    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
-    dependencies:
-      has-bigints: 1.0.2
-    dev: true
-
-  /is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-    dependencies:
-      binary-extensions: 2.3.0
-
-  /is-boolean-object@1.1.2:
-    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.7
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-core-module@2.13.1:
-    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
-    dependencies:
-      hasown: 2.0.2
-    dev: true
-
-  /is-data-view@1.0.1:
-    resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      is-typed-array: 1.1.13
-    dev: true
-
-  /is-date-object@1.0.5:
-    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-    dev: false
-
-  /is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  /is-finalizationregistry@1.0.2:
-    resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
-    dependencies:
-      call-bind: 1.0.7
-    dev: true
-
-  /is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: 2.1.1
-
-  /is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
-    dependencies:
-      is-docker: 3.0.0
-    dev: false
-
-  /is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-number-object@1.0.7:
-    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
-  /is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-potential-custom-element-name@1.0.1:
-    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-    dev: true
-
-  /is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-    dev: true
-
-  /is-regex@1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.7
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-shared-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.7
-    dev: true
-
-  /is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
-
-  /is-string@1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.2
-    dev: true
-
-  /is-symbol@1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: 1.0.3
-    dev: true
-
-  /is-typed-array@1.1.13:
-    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      which-typed-array: 1.1.15
-    dev: true
-
-  /is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-    dev: false
-
-  /is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /is-unicode-supported@2.0.0:
-    resolution: {integrity: sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-weakref@1.0.2:
-    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
-    dependencies:
-      call-bind: 1.0.7
-    dev: true
-
-  /is-weakset@2.0.3:
-    resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.7
-      get-intrinsic: 1.2.4
-    dev: true
-
-  /is-wsl@3.1.0:
-    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
-    engines: {node: '>=16'}
-    dependencies:
-      is-inside-container: 1.0.0
-    dev: false
-
-  /is64bit@2.0.0:
-    resolution: {integrity: sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==}
-    engines: {node: '>=18'}
-    dependencies:
-      system-architecture: 0.1.0
-    dev: false
-
-  /isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-    dev: true
-
-  /isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  /istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /istanbul-lib-instrument@5.2.1:
-    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
-    engines: {node: '>=8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/core': 7.18.10
       '@babel/parser': 7.18.11
@@ -11100,45 +7068,22 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   iterator.prototype@1.1.2:
-=======
-    dev: true
-
-  /iterator.prototype@1.1.2:
-    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       define-properties: 1.2.1
       get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       reflect.getprototypeof: 1.0.6
       set-function-name: 2.0.2
-<<<<<<< HEAD
 
   jackspeak@3.4.0:
-=======
-    dev: true
-
-  /jackspeak@3.4.0:
-    resolution: {integrity: sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==}
-    engines: {node: '>=14'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-<<<<<<< HEAD
 
   jest-haste-map@28.1.3:
-=======
-    dev: true
-
-  /jest-haste-map@28.1.3:
-    resolution: {integrity: sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.9
@@ -11153,23 +7098,10 @@ snapshots:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
-<<<<<<< HEAD
 
   jest-regex-util@28.0.2: {}
 
   jest-util@28.1.3:
-=======
-    dev: true
-
-  /jest-regex-util@28.0.2:
-    resolution: {integrity: sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dev: true
-
-  /jest-util@28.1.3:
-    resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@jest/types': 28.1.3
       '@types/node': 20.14.2
@@ -11177,21 +7109,12 @@ snapshots:
       ci-info: 3.9.0
       graceful-fs: 4.2.11
       picomatch: 2.3.1
-<<<<<<< HEAD
 
   jest-worker@28.1.3:
-=======
-    dev: true
-
-  /jest-worker@28.1.3:
-    resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@types/node': 20.14.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
-<<<<<<< HEAD
 
   jiti@1.21.3: {}
 
@@ -11211,47 +7134,6 @@ snapshots:
       argparse: 2.0.1
 
   jsdom@24.1.0:
-=======
-    dev: true
-
-  /jiti@1.21.3:
-    resolution: {integrity: sha512-uy2bNX5zQ+tESe+TiC7ilGRz8AtRGmnJH55NC5S0nSUjvvvM2hJHmefHErugGXN4pNv4Qx7vLsnNw9qJ9mtIsw==}
-    hasBin: true
-    dev: false
-
-  /joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
-
-  /js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
-    hasBin: true
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-    dev: true
-
-  /js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-    dependencies:
-      argparse: 2.0.1
-    dev: true
-
-  /jsdom@24.1.0:
-    resolution: {integrity: sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      canvas: ^2.11.2
-    peerDependenciesMeta:
-      canvas:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       cssstyle: 4.0.1
       data-urls: 5.0.0
@@ -11278,7 +7160,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-<<<<<<< HEAD
 
   jsesc@0.5.0: {}
 
@@ -11295,52 +7176,11 @@ snapshots:
   json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
-=======
-    dev: true
-
-  /jsesc@0.5.0:
-    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
-    hasBin: true
-    dev: true
-
-  /jsesc@2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: true
-
-  /json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: true
-
-  /json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
-
-  /json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
-
-  /json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-    dev: true
-
-  /json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: true
-
-  /jsx-ast-utils@3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
-    engines: {node: '>=4.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
-<<<<<<< HEAD
 
   keyv@4.5.4:
     dependencies:
@@ -11366,56 +7206,6 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   listhen@1.7.2:
-=======
-    dev: true
-
-  /keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-    dependencies:
-      json-buffer: 3.0.1
-    dev: true
-
-  /keyvaluestorage-interface@1.0.0:
-    resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
-    dev: false
-
-  /kleur@3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /language-subtag-registry@0.3.23:
-    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
-    dev: true
-
-  /language-tags@1.0.9:
-    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      language-subtag-registry: 0.3.23
-    dev: true
-
-  /levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-    dev: true
-
-  /lilconfig@3.1.1:
-    resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
-    engines: {node: '>=14'}
-    dev: true
-
-  /lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
-
-  /listhen@1.7.2:
-    resolution: {integrity: sha512-7/HamOm5YD9Wb7CFgAZkKgVPA96WwhcTQoqtm2VTZGVbVVn3IWKRBTgrU7cchA3Q8k9iCsG8Osoi9GX4JsGM9g==}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@parcel/watcher': 2.4.1
       '@parcel/watcher-wasm': 2.4.1
@@ -11437,7 +7227,6 @@ snapshots:
       uqr: 0.1.2
     transitivePeerDependencies:
       - uWebSockets.js
-<<<<<<< HEAD
 
   load-tsconfig@0.2.5: {}
 
@@ -11491,104 +7280,6 @@ snapshots:
       tmpl: 1.0.5
 
   memoizee@0.4.17:
-=======
-    dev: false
-
-  /load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
-  /locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
-    dependencies:
-      p-locate: 4.1.0
-    dev: true
-
-  /locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
-    dependencies:
-      p-locate: 5.0.0
-    dev: true
-
-  /lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: false
-
-  /lodash.debounce@4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-    dev: true
-
-  /lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    dev: false
-
-  /lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
-
-  /lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-    dev: true
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
-
-  /log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
-    engines: {node: '>=18'}
-    dependencies:
-      chalk: 5.3.0
-      is-unicode-supported: 1.3.0
-    dev: true
-
-  /long@5.2.3:
-    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
-    dev: true
-
-  /loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-    dependencies:
-      js-tokens: 4.0.0
-    dev: true
-
-  /lru-cache@10.2.2:
-    resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
-    engines: {node: 14 || >=16.14}
-
-  /lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-    dependencies:
-      yallist: 3.1.1
-    dev: true
-
-  /lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-    dependencies:
-      yallist: 4.0.0
-    dev: true
-
-  /lru-queue@0.1.0:
-    resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
-    dependencies:
-      es5-ext: 0.10.64
-    dev: true
-
-  /makeerror@1.0.12:
-    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
-    dependencies:
-      tmpl: 1.0.5
-    dev: true
-
-  /memoizee@0.4.17:
-    resolution: {integrity: sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==}
-    engines: {node: '>=0.12'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
@@ -11598,33 +7289,16 @@ snapshots:
       lru-queue: 0.1.0
       next-tick: 1.1.0
       timers-ext: 0.1.8
-<<<<<<< HEAD
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
   micromatch@4.0.7:
-=======
-    dev: true
-
-  /merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-
-  /merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /micromatch@4.0.7:
-    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
-    engines: {node: '>=8.6'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
 
-<<<<<<< HEAD
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -11660,88 +7334,11 @@ snapshots:
   mkdirp@1.0.4: {}
 
   mlly@1.7.1:
-=======
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.52.0
-    dev: true
-
-  /mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    dev: false
-
-  /mimic-fn@1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /minimalistic-assert@1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-    dev: false
-
-  /minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: true
-
-  /minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
-  /minimatch@9.0.4:
-    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
-  /minimist@1.2.6:
-    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-    dev: true
-
-  /minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
-
-  /mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
-  /mlly@1.7.1:
-    resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       acorn: 8.11.3
       pathe: 1.1.2
       pkg-types: 1.1.1
       ufo: 1.5.3
-<<<<<<< HEAD
 
   mri@1.2.0: {}
 
@@ -11752,36 +7349,14 @@ snapshots:
   mute-stream@0.0.7: {}
 
   mz@2.7.0:
-=======
-    dev: false
-
-  /mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
-
-  /multiformats@9.9.0:
-    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
-    dev: false
-
-  /mute-stream@0.0.7:
-    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
-    dev: true
-
-  /mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-<<<<<<< HEAD
 
   natural-compare@1.4.0: {}
+
+  neverthrow@6.2.2: {}
 
   next-tick@1.1.0: {}
 
@@ -11798,53 +7373,11 @@ snapshots:
   normalize-path@3.0.0: {}
 
   npm-package-arg@11.0.2:
-=======
-    dev: true
-
-  /natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-    dev: true
-
-  /next-tick@1.1.0:
-    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
-    dev: true
-
-  /node-addon-api@7.1.0:
-    resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}
-    engines: {node: ^16 || ^18 || >= 20}
-    dev: false
-
-  /node-fetch-native@1.6.4:
-    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
-    dev: false
-
-  /node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
-    engines: {node: '>= 6.13.0'}
-    dev: false
-
-  /node-int64@0.4.0:
-    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
-    dev: true
-
-  /node-releases@2.0.14:
-    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
-    dev: true
-
-  /normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  /npm-package-arg@11.0.2:
-    resolution: {integrity: sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==}
-    engines: {node: ^16.14.0 || >=18.0.0}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
       semver: 7.6.0
       validate-npm-package-name: 5.0.1
-<<<<<<< HEAD
 
   npm-run-path@4.0.1:
     dependencies:
@@ -11863,121 +7396,42 @@ snapshots:
   object-keys@1.1.1: {}
 
   object.assign@4.1.5:
-=======
-    dev: true
-
-  /npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-key: 3.1.1
-    dev: true
-
-  /npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      path-key: 4.0.0
-    dev: false
-
-  /nwsapi@2.2.10:
-    resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
-    dev: true
-
-  /object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /object-inspect@1.13.1:
-    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
-    dev: true
-
-  /object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /object.assign@4.1.5:
-    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
-<<<<<<< HEAD
 
   object.entries@1.1.8:
-=======
-    dev: true
-
-  /object.entries@1.1.8:
-    resolution: {integrity: sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   object.fromentries@2.0.8:
-=======
-    dev: true
-
-  /object.fromentries@2.0.8:
-    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   object.hasown@1.1.4:
-=======
-    dev: true
-
-  /object.hasown@1.1.4:
-    resolution: {integrity: sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   object.values@1.2.0:
-=======
-    dev: true
-
-  /object.values@1.2.0:
-    resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   ofetch@1.3.4:
-=======
-    dev: true
-
-  /ofetch@1.3.4:
-    resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       destr: 2.0.3
       node-fetch-native: 1.6.4
       ufo: 1.5.3
-<<<<<<< HEAD
 
   ohash@1.1.3: {}
 
@@ -12000,47 +7454,6 @@ snapshots:
       mimic-fn: 4.0.0
 
   optionator@0.9.4:
-=======
-    dev: false
-
-  /ohash@1.1.3:
-    resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
-    dev: false
-
-  /on-exit-leak-free@0.2.0:
-    resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
-    dev: false
-
-  /once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-    dependencies:
-      wrappy: 1.0.2
-
-  /onetime@2.0.1:
-    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      mimic-fn: 1.2.0
-    dev: true
-
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
-    dependencies:
-      mimic-fn: 2.1.0
-    dev: true
-
-  /onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      mimic-fn: 4.0.0
-    dev: false
-
-  /optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
@@ -12048,16 +7461,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-<<<<<<< HEAD
 
   ora@8.0.1:
-=======
-    dev: true
-
-  /ora@8.0.1:
-    resolution: {integrity: sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==}
-    engines: {node: '>=18'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       chalk: 5.3.0
       cli-cursor: 4.0.0
@@ -12068,7 +7473,6 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.1.0
       strip-ansi: 7.1.0
-<<<<<<< HEAD
 
   os-tmpdir@1.0.2: {}
 
@@ -12097,64 +7501,11 @@ snapshots:
       callsites: 3.1.0
 
   parse-json@5.2.0:
-=======
-    dev: true
-
-  /os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-try: 2.2.0
-    dev: true
-
-  /p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      yocto-queue: 0.1.0
-    dev: true
-
-  /p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
-    dependencies:
-      p-limit: 2.3.0
-    dev: true
-
-  /p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
-    dependencies:
-      p-limit: 3.1.0
-    dev: true
-
-  /p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-    dependencies:
-      callsites: 3.1.0
-    dev: true
-
-  /parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-<<<<<<< HEAD
 
   parse-package-name@1.0.0: {}
 
@@ -12195,87 +7546,6 @@ snapshots:
   pino-std-serializers@4.0.0: {}
 
   pino@7.11.0:
-=======
-    dev: true
-
-  /parse-package-name@1.0.0:
-    resolution: {integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==}
-    dev: true
-
-  /parse5@7.1.2:
-    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
-    dependencies:
-      entities: 4.5.0
-    dev: true
-
-  /path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  /path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
-
-  /path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-    dependencies:
-      lru-cache: 10.2.2
-      minipass: 7.1.2
-    dev: true
-
-  /path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /path-type@5.0.0:
-    resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-    dev: false
-
-  /picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
-    dev: true
-
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
-  /pino-abstract-transport@0.5.0:
-    resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
-    dependencies:
-      duplexify: 4.1.3
-      split2: 4.2.0
-    dev: false
-
-  /pino-std-serializers@4.0.0:
-    resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
-    dev: false
-
-  /pino@7.11.0:
-    resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       atomic-sleep: 1.0.0
       fast-redact: 3.5.0
@@ -12288,27 +7558,14 @@ snapshots:
       safe-stable-stringify: 2.4.3
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
-<<<<<<< HEAD
 
   pirates@4.0.6: {}
 
   pkg-types@1.1.1:
-=======
-    dev: false
-
-  /pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /pkg-types@1.1.1:
-    resolution: {integrity: sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       confbox: 0.1.7
       mlly: 1.7.1
       pathe: 1.1.2
-<<<<<<< HEAD
 
   possible-typed-array-names@1.0.0: {}
 
@@ -12341,134 +7598,10 @@ snapshots:
       sisteransi: 1.0.5
 
   prop-types@15.8.1:
-=======
-    dev: false
-
-  /possible-typed-array-names@1.0.0:
-    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 3.1.1
-      yaml: 2.4.3
-    dev: true
-
-  /prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
-    dev: true
-
-  /prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      fast-diff: 1.3.0
-    dev: true
-
-  /prettier-plugin-tailwindcss@0.6.1(prettier@3.3.1):
-    resolution: {integrity: sha512-AnbeYZu0WGj+QgKciUgdMnRxrqcxltleZPgdwfA5104BHM3siBLONN/HLW1yS2HvzSNkzpQ/JAj+LN0jcJO+0w==}
-    engines: {node: '>=14.21.3'}
-    peerDependencies:
-      '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-pug': '*'
-      '@shopify/prettier-plugin-liquid': '*'
-      '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig-melody': '*'
-      prettier: ^3.0
-      prettier-plugin-astro: '*'
-      prettier-plugin-css-order: '*'
-      prettier-plugin-import-sort: '*'
-      prettier-plugin-jsdoc: '*'
-      prettier-plugin-marko: '*'
-      prettier-plugin-organize-attributes: '*'
-      prettier-plugin-organize-imports: '*'
-      prettier-plugin-sort-imports: '*'
-      prettier-plugin-style-order: '*'
-      prettier-plugin-svelte: '*'
-    peerDependenciesMeta:
-      '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-pug':
-        optional: true
-      '@shopify/prettier-plugin-liquid':
-        optional: true
-      '@trivago/prettier-plugin-sort-imports':
-        optional: true
-      '@zackad/prettier-plugin-twig-melody':
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-      prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-import-sort:
-        optional: true
-      prettier-plugin-jsdoc:
-        optional: true
-      prettier-plugin-marko:
-        optional: true
-      prettier-plugin-organize-attributes:
-        optional: true
-      prettier-plugin-organize-imports:
-        optional: true
-      prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-style-order:
-        optional: true
-      prettier-plugin-svelte:
-        optional: true
-    dependencies:
-      prettier: 3.3.1
-    dev: true
-
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: true
-
-  /prettier@3.3.1:
-    resolution: {integrity: sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
-  /proc-log@4.2.0:
-    resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: true
-
-  /process-warning@1.0.0:
-    resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
-    dev: false
-
-  /prompts@2.4.2:
-    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
-    engines: {node: '>= 6'}
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
-    dev: true
-
-  /prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-<<<<<<< HEAD
 
   psl@1.9.0: {}
 
@@ -12477,47 +7610,18 @@ snapshots:
   pure-rand@6.1.0: {}
 
   query-string@6.14.1:
-=======
-    dev: true
-
-  /psl@1.9.0:
-    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
-    dev: true
-
-  /punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
-    dev: true
-
-  /query-string@6.14.1:
-    resolution: {integrity: sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==}
-    engines: {node: '>=6'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       decode-uri-component: 0.2.2
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
-<<<<<<< HEAD
 
   query-string@7.1.3:
-=======
-    dev: false
-
-  /query-string@7.1.3:
-    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
-    engines: {node: '>=6'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       decode-uri-component: 0.2.2
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
-<<<<<<< HEAD
 
   querystringify@2.2.0: {}
 
@@ -12539,52 +7643,10 @@ snapshots:
       strip-bom: 4.0.0
 
   readable-stream@3.6.2:
-=======
-    dev: false
-
-  /querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-    dev: true
-
-  /queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
-
-  /quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-    dev: false
-
-  /radix3@1.1.2:
-    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
-    dev: false
-
-  /randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
-
-  /read-yaml-file@2.1.0:
-    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
-    engines: {node: '>=10.13'}
-    dependencies:
-      js-yaml: 4.1.0
-      strip-bom: 4.0.0
-    dev: true
-
-  /readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-<<<<<<< HEAD
 
   readdirp@3.6.0:
     dependencies:
@@ -12597,31 +7659,6 @@ snapshots:
       resolve: 1.22.8
 
   reflect.getprototypeof@1.0.6:
-=======
-    dev: false
-
-  /readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-    dependencies:
-      picomatch: 2.3.1
-
-  /real-require@0.1.0:
-    resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
-    engines: {node: '>= 12.13.0'}
-    dev: false
-
-  /rechoir@0.6.2:
-    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      resolve: 1.22.8
-    dev: true
-
-  /reflect.getprototypeof@1.0.6:
-    resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -12630,7 +7667,6 @@ snapshots:
       get-intrinsic: 1.2.4
       globalthis: 1.0.4
       which-builtin-type: 1.1.3
-<<<<<<< HEAD
 
   regenerate-unicode-properties@10.1.1:
     dependencies:
@@ -12645,49 +7681,13 @@ snapshots:
       '@babel/runtime': 7.24.7
 
   regexp.prototype.flags@1.5.2:
-=======
-    dev: true
-
-  /regenerate-unicode-properties@10.1.1:
-    resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
-    engines: {node: '>=4'}
-    dependencies:
-      regenerate: 1.4.2
-    dev: true
-
-  /regenerate@1.4.2:
-    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
-    dev: true
-
-  /regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-    dev: true
-
-  /regenerator-transform@0.15.2:
-    resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
-    dependencies:
-      '@babel/runtime': 7.24.7
-    dev: true
-
-  /regexp.prototype.flags@1.5.2:
-    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
-<<<<<<< HEAD
 
   regexpu-core@5.3.2:
-=======
-    dev: true
-
-  /regexpu-core@5.3.2:
-    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
-    engines: {node: '>=4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/regjsgen': 0.8.0
       regenerate: 1.4.2
@@ -12695,7 +7695,6 @@ snapshots:
       regjsparser: 0.9.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.1.0
-<<<<<<< HEAD
 
   regjsparser@0.9.1:
     dependencies:
@@ -12708,53 +7707,16 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve@1.22.8:
-=======
-    dev: true
-
-  /regjsparser@0.9.1:
-    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
-    hasBin: true
-    dependencies:
-      jsesc: 0.5.0
-    dev: true
-
-  /requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-    dev: true
-
-  /resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /resolve@1.22.8:
-    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-<<<<<<< HEAD
 
   resolve@2.0.0-next.5:
-=======
-    dev: true
-
-  /resolve@2.0.0-next.5:
-    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-<<<<<<< HEAD
 
   restore-cursor@2.0.0:
     dependencies:
@@ -12773,43 +7735,6 @@ snapshots:
       glob: 7.2.3
 
   rollup@4.18.0:
-=======
-    dev: true
-
-  /restore-cursor@2.0.0:
-    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
-    engines: {node: '>=4'}
-    dependencies:
-      onetime: 2.0.1
-      signal-exit: 3.0.7
-    dev: true
-
-  /restore-cursor@4.0.0:
-    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-    dev: true
-
-  /reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
-
-  /rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-    dev: true
-
-  /rollup@4.18.0:
-    resolution: {integrity: sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
@@ -12830,7 +7755,6 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.18.0
       '@rollup/rollup-win32-x64-msvc': 4.18.0
       fsevents: 2.3.3
-<<<<<<< HEAD
 
   rrweb-cssom@0.6.0: {}
 
@@ -12853,75 +7777,19 @@ snapshots:
       tslib: 1.14.1
 
   safe-array-concat@1.1.2:
-=======
-    dev: true
-
-  /rrweb-cssom@0.6.0:
-    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
-    dev: true
-
-  /rrweb-cssom@0.7.0:
-    resolution: {integrity: sha512-KlSv0pm9kgQSRxXEMgtivPJ4h826YHsuob8pSHcfSZsSXGtvpEAie8S0AnXuObEJ7nhikOb4ahwxDm0H2yW17g==}
-    dev: true
-
-  /run-async@2.4.1:
-    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
-    engines: {node: '>=0.12.0'}
-    dev: true
-
-  /run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-    dependencies:
-      queue-microtask: 1.2.3
-    dev: true
-
-  /rx-lite-aggregates@4.0.8:
-    resolution: {integrity: sha512-3xPNZGW93oCjiO7PtKxRK6iOVYBWBvtf9QHDfU23Oc+dLIQmAV//UnyXV/yihv81VS/UqoQPk4NegS8EFi55Hg==}
-    dependencies:
-      rx-lite: 4.0.8
-    dev: true
-
-  /rx-lite@4.0.8:
-    resolution: {integrity: sha512-Cun9QucwK6MIrp3mry/Y7hqD1oFqTYLQ4pGxaHTjIdaFDWRGGLikqp6u8LcWJnzpoALg9hap+JGk8sFIUuEGNA==}
-    dev: true
-
-  /rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
-    dependencies:
-      tslib: 1.14.1
-    dev: true
-
-  /safe-array-concat@1.1.2:
-    resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
-    engines: {node: '>=0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       isarray: 2.0.5
-<<<<<<< HEAD
 
   safe-buffer@5.2.1: {}
 
   safe-regex-test@1.0.3:
-=======
-    dev: true
-
-  /safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
-
-  /safe-regex-test@1.0.3:
-    resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-regex: 1.1.4
-<<<<<<< HEAD
 
   safe-stable-stringify@2.4.3: {}
 
@@ -12940,48 +7808,6 @@ snapshots:
   semver@7.6.2: {}
 
   set-function-length@1.2.2:
-=======
-    dev: true
-
-  /safe-stable-stringify@2.4.3:
-    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
-    engines: {node: '>=10'}
-    dev: false
-
-  /safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
-
-  /saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
-    dependencies:
-      xmlchars: 2.2.0
-    dev: true
-
-  /semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-    dev: true
-
-  /semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
-  /semver@7.6.2:
-    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
-  /set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       define-data-property: 1.1.4
       es-errors: 1.3.0
@@ -12989,22 +7815,13 @@ snapshots:
       get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
-<<<<<<< HEAD
 
   set-function-name@2.0.2:
-=======
-    dev: true
-
-  /set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       define-data-property: 1.1.4
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
-<<<<<<< HEAD
 
   shebang-command@2.0.0:
     dependencies:
@@ -13013,44 +7830,17 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shelljs@0.8.5:
-=======
-    dev: true
-
-  /shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-    dependencies:
-      shebang-regex: 3.0.0
-
-  /shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  /shelljs@0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       glob: 7.2.3
       interpret: 1.4.0
       rechoir: 0.6.2
-<<<<<<< HEAD
 
   side-channel@1.0.6:
-=======
-    dev: true
-
-  /side-channel@1.0.6:
-    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
-<<<<<<< HEAD
 
   signal-exit@3.0.7: {}
 
@@ -13090,130 +7880,24 @@ snapshots:
       strip-ansi: 4.0.0
 
   string-width@4.2.3:
-=======
-    dev: true
-
-  /signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: true
-
-  /signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
-  /sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: true
-
-  /slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
-    dev: true
-
-  /sonic-boom@2.8.0:
-    resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
-    dependencies:
-      atomic-sleep: 1.0.0
-    dev: false
-
-  /source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      whatwg-url: 7.1.0
-    dev: true
-
-  /split-on-first@1.1.0:
-    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-    dev: false
-
-  /sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-    dev: true
-
-  /std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
-    dev: false
-
-  /stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /stream-shift@1.0.3:
-    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
-    dev: false
-
-  /strict-uri-encode@2.0.0:
-    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-    dev: true
-
-  /string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-<<<<<<< HEAD
 
   string-width@5.1.2:
-=======
-    dev: true
-
-  /string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-<<<<<<< HEAD
 
   string-width@7.1.0:
-=======
-    dev: true
-
-  /string-width@7.1.0:
-    resolution: {integrity: sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==}
-    engines: {node: '>=18'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       emoji-regex: 10.3.0
       get-east-asian-width: 1.2.0
       strip-ansi: 7.1.0
-<<<<<<< HEAD
 
   string.prototype.matchall@4.0.11:
-=======
-    dev: true
-
-  /string.prototype.matchall@4.0.11:
-    resolution: {integrity: sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -13227,49 +7911,25 @@ snapshots:
       regexp.prototype.flags: 1.5.2
       set-function-name: 2.0.2
       side-channel: 1.0.6
-<<<<<<< HEAD
 
   string.prototype.trim@1.2.9:
-=======
-    dev: true
-
-  /string.prototype.trim@1.2.9:
-    resolution: {integrity: sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   string.prototype.trimend@1.0.8:
-=======
-    dev: true
-
-  /string.prototype.trimend@1.0.8:
-    resolution: {integrity: sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   string.prototype.trimstart@1.0.8:
-=======
-    dev: true
-
-  /string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
-<<<<<<< HEAD
 
   string_decoder@1.3.0:
     dependencies:
@@ -13304,75 +7964,6 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   sucrase@3.35.0:
-=======
-    dev: true
-
-  /string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: true
-
-  /strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-regex: 3.0.1
-    dev: true
-
-  /strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
-    dependencies:
-      ansi-regex: 4.1.1
-    dev: true
-
-  /strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-regex: 5.0.1
-    dev: true
-
-  /strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-regex: 6.0.1
-    dev: true
-
-  /strip-bom@4.0.0:
-    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       commander: 4.1.1
@@ -13381,7 +7972,6 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
-<<<<<<< HEAD
 
   supports-color@2.0.0: {}
 
@@ -13407,57 +7997,6 @@ snapshots:
       tslib: 2.6.3
 
   syncpack@12.3.2(typescript@5.4.5):
-=======
-    dev: true
-
-  /supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  /supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-    dependencies:
-      has-flag: 3.0.0
-    dev: true
-
-  /supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-    dependencies:
-      has-flag: 4.0.0
-    dev: true
-
-  /supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      has-flag: 4.0.0
-    dev: true
-
-  /supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /symbol-tree@3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: true
-
-  /synckit@0.8.8:
-    resolution: {integrity: sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    dependencies:
-      '@pkgr/core': 0.1.1
-      tslib: 2.6.3
-    dev: true
-
-  /syncpack@12.3.2(typescript@5.4.5):
-    resolution: {integrity: sha512-ePvaDfasxF8mwaPItN6urmABaH6FPT3/vJU+2DHt24j8EIKjgz6NCxXDx2bTXJXZ4QcEFwvoiu3EqaJsVrHvUg==}
-    engines: {node: '>=16'}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@effect/schema': 0.66.5(effect@3.0.3)(fast-check@3.17.2)
       chalk: 5.3.0
@@ -13478,28 +8017,14 @@ snapshots:
       ts-toolbelt: 9.6.0
     transitivePeerDependencies:
       - typescript
-<<<<<<< HEAD
 
   system-architecture@0.1.0: {}
 
   test-exclude@6.0.0:
-=======
-    dev: true
-
-  /system-architecture@0.1.0:
-    resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
-    engines: {node: '>=18'}
-    dev: false
-
-  /test-exclude@6.0.0:
-    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
-    engines: {node: '>=8'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
-<<<<<<< HEAD
 
   text-table@0.2.0: {}
 
@@ -13537,81 +8062,11 @@ snapshots:
       is-number: 7.0.0
 
   tough-cookie@4.1.4:
-=======
-    dev: true
-
-  /text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-    dev: true
-
-  /thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      thenify: 3.3.1
-    dev: true
-
-  /thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-    dependencies:
-      any-promise: 1.3.0
-    dev: true
-
-  /thread-stream@0.15.2:
-    resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
-    dependencies:
-      real-require: 0.1.0
-    dev: false
-
-  /through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-    dev: true
-
-  /tightrope@0.2.0:
-    resolution: {integrity: sha512-Kw36UHxJEELq2VUqdaSGR2/8cAsPgMtvX8uGVU6Jk26O66PhXec0A5ZnRYs47btbtwPDpXXF66+Fo3vimCM9aQ==}
-    engines: {node: '>=16'}
-    dev: true
-
-  /timers-ext@0.1.8:
-    resolution: {integrity: sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==}
-    engines: {node: '>=0.12'}
-    dependencies:
-      es5-ext: 0.10.64
-      next-tick: 1.1.0
-    dev: true
-
-  /tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
-    dependencies:
-      os-tmpdir: 1.0.2
-    dev: true
-
-  /tmpl@1.0.5:
-    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
-    dev: true
-
-  /to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-    dependencies:
-      is-number: 7.0.0
-
-  /tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
-    engines: {node: '>=6'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       psl: 1.9.0
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
-<<<<<<< HEAD
 
   tr46@1.0.1:
     dependencies:
@@ -13636,70 +8091,6 @@ snapshots:
   tslib@2.6.3: {}
 
   tsup@8.1.0(typescript@5.4.5):
-=======
-    dev: true
-
-  /tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-    dependencies:
-      punycode: 2.3.1
-    dev: true
-
-  /tr46@5.0.0:
-    resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
-    engines: {node: '>=18'}
-    dependencies:
-      punycode: 2.3.1
-    dev: true
-
-  /tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-    dev: true
-
-  /ts-api-utils@1.3.0(typescript@5.4.5):
-    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      typescript: '>=4.2.0'
-    dependencies:
-      typescript: 5.4.5
-    dev: true
-
-  /ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: true
-
-  /ts-toolbelt@9.6.0:
-    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
-    dev: true
-
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
-  /tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
-    dev: true
-
-  /tsup@8.1.0(typescript@5.4.5):
-    resolution: {integrity: sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.4)
       cac: 6.7.14
@@ -13715,15 +8106,11 @@ snapshots:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
-<<<<<<< HEAD
     optionalDependencies:
-=======
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
       - ts-node
-<<<<<<< HEAD
 
   type-check@0.4.0:
     dependencies:
@@ -13734,54 +8121,20 @@ snapshots:
   type@2.7.3: {}
 
   typed-array-buffer@1.0.2:
-=======
-    dev: true
-
-  /type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: 1.2.1
-    dev: true
-
-  /type@2.7.3:
-    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
-    dev: true
-
-  /typed-array-buffer@1.0.2:
-    resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-typed-array: 1.1.13
-<<<<<<< HEAD
 
   typed-array-byte-length@1.0.1:
-=======
-    dev: true
-
-  /typed-array-byte-length@1.0.1:
-    resolution: {integrity: sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       for-each: 0.3.3
       gopd: 1.0.1
       has-proto: 1.0.3
       is-typed-array: 1.1.13
-<<<<<<< HEAD
 
   typed-array-byte-offset@1.0.2:
-=======
-    dev: true
-
-  /typed-array-byte-offset@1.0.2:
-    resolution: {integrity: sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.7
@@ -13789,16 +8142,8 @@ snapshots:
       gopd: 1.0.1
       has-proto: 1.0.3
       is-typed-array: 1.1.13
-<<<<<<< HEAD
 
   typed-array-length@1.0.6:
-=======
-    dev: true
-
-  /typed-array-length@1.0.6:
-    resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       for-each: 0.3.3
@@ -13806,7 +8151,6 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
-<<<<<<< HEAD
 
   typedarray-to-buffer@3.1.5:
     dependencies:
@@ -13832,86 +8176,23 @@ snapshots:
       multiformats: 9.9.0
 
   unbox-primitive@1.0.2:
-=======
-    dev: true
-
-  /typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
-    dependencies:
-      is-typedarray: 1.0.0
-    dev: false
-
-  /typescript-eslint@7.12.0(eslint@9.4.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-D6HKNbQcnNu3BaN4HkQCR16tgG8Q2AMUWPgvhrJksOXu+d6ys07yC06ONiV2kcsEfWC22voB6C3PvK2MqlBZ7w==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 7.12.0(@typescript-eslint/parser@7.12.0)(eslint@9.4.0)(typescript@5.4.5)
-      '@typescript-eslint/parser': 7.12.0(eslint@9.4.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.12.0(eslint@9.4.0)(typescript@5.4.5)
-      eslint: 9.4.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
-  /ufo@1.5.3:
-    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
-    dev: false
-
-  /uint8arrays@3.1.1:
-    resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
-    dependencies:
-      multiformats: 9.9.0
-    dev: false
-
-  /unbox-primitive@1.0.2:
-    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       call-bind: 1.0.7
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
-<<<<<<< HEAD
 
   uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 
   unenv@1.9.0:
-=======
-    dev: true
-
-  /uncrypto@0.1.3:
-    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-    dev: false
-
-  /undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
-
-  /unenv@1.9.0:
-    resolution: {integrity: sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       consola: 3.2.3
       defu: 6.1.4
       mime: 3.0.0
       node-fetch-native: 1.6.4
       pathe: 1.1.2
-<<<<<<< HEAD
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -13929,138 +8210,33 @@ snapshots:
   universalify@0.2.0: {}
 
   unstorage@1.10.2(idb-keyval@6.2.1):
-=======
-    dev: false
-
-  /unicode-canonical-property-names-ecmascript@2.0.0:
-    resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicode-match-property-ecmascript@2.0.0:
-    resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
-    engines: {node: '>=4'}
-    dependencies:
-      unicode-canonical-property-names-ecmascript: 2.0.0
-      unicode-property-aliases-ecmascript: 2.1.0
-    dev: true
-
-  /unicode-match-property-value-ecmascript@2.1.0:
-    resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicode-property-aliases-ecmascript@2.1.0:
-    resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicorn-magic@0.1.0:
-    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-    dev: true
-
-  /unstorage@1.10.2(idb-keyval@6.2.1):
-    resolution: {integrity: sha512-cULBcwDqrS8UhlIysUJs2Dk0Mmt8h7B0E6mtR+relW9nZvsf/u4SkAYyNliPiPW7XtFNb5u3IUMkxGxFTTRTgQ==}
-    peerDependencies:
-      '@azure/app-configuration': ^1.5.0
-      '@azure/cosmos': ^4.0.0
-      '@azure/data-tables': ^13.2.2
-      '@azure/identity': ^4.0.1
-      '@azure/keyvault-secrets': ^4.8.0
-      '@azure/storage-blob': ^12.17.0
-      '@capacitor/preferences': ^5.0.7
-      '@netlify/blobs': ^6.5.0 || ^7.0.0
-      '@planetscale/database': ^1.16.0
-      '@upstash/redis': ^1.28.4
-      '@vercel/kv': ^1.0.1
-      idb-keyval: ^6.2.1
-      ioredis: ^5.3.2
-    peerDependenciesMeta:
-      '@azure/app-configuration':
-        optional: true
-      '@azure/cosmos':
-        optional: true
-      '@azure/data-tables':
-        optional: true
-      '@azure/identity':
-        optional: true
-      '@azure/keyvault-secrets':
-        optional: true
-      '@azure/storage-blob':
-        optional: true
-      '@capacitor/preferences':
-        optional: true
-      '@netlify/blobs':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@upstash/redis':
-        optional: true
-      '@vercel/kv':
-        optional: true
-      idb-keyval:
-        optional: true
-      ioredis:
-        optional: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       anymatch: 3.1.3
       chokidar: 3.6.0
       destr: 2.0.3
       h3: 1.11.1
-<<<<<<< HEAD
-=======
-      idb-keyval: 6.2.1
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
       listhen: 1.7.2
       lru-cache: 10.2.2
       mri: 1.2.0
       node-fetch-native: 1.6.4
       ofetch: 1.3.4
       ufo: 1.5.3
-<<<<<<< HEAD
     optionalDependencies:
       idb-keyval: 6.2.1
     transitivePeerDependencies:
       - uWebSockets.js
 
   untun@0.1.3:
-=======
-    transitivePeerDependencies:
-      - uWebSockets.js
-    dev: false
-
-  /untun@0.1.3:
-    resolution: {integrity: sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==}
-    hasBin: true
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       citty: 0.1.6
       consola: 3.2.3
       pathe: 1.1.2
-<<<<<<< HEAD
 
   update-browserslist-db@1.0.16(browserslist@4.23.0):
-=======
-    dev: false
-
-  /update-browserslist-db@1.0.16(browserslist@4.23.0):
-    resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.2
       picocolors: 1.0.1
-<<<<<<< HEAD
 
   uqr@0.1.2: {}
 
@@ -14090,57 +8266,6 @@ snapshots:
       makeerror: 1.0.12
 
   wasm-ast-types@0.26.4:
-=======
-    dev: true
-
-  /uqr@0.1.2:
-    resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
-    dev: false
-
-  /uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-    dependencies:
-      punycode: 2.3.1
-    dev: true
-
-  /url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-    dev: true
-
-  /util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: false
-
-  /util@0.10.4:
-    resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
-    dependencies:
-      inherits: 2.0.3
-    dev: true
-
-  /validate-npm-package-name@5.0.1:
-    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: true
-
-  /w3c-xmlserializer@5.0.0:
-    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
-    engines: {node: '>=18'}
-    dependencies:
-      xml-name-validator: 5.0.0
-    dev: true
-
-  /walker@1.0.8:
-    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
-    dependencies:
-      makeerror: 1.0.12
-    dev: true
-
-  /wasm-ast-types@0.26.4:
-    resolution: {integrity: sha512-bMxkQzc/+e7s5W+EBfurl/Y7KnTm0YPeg/cXjyio3PHULKWQULMREgyuJXJWaIa+8sKI1+OI61YeFSJBilm9YQ==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       '@babel/runtime': 7.24.7
       '@babel/types': 7.18.10
@@ -14150,7 +8275,6 @@ snapshots:
       deepmerge: 4.2.2
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
 
   webidl-conversions@4.0.2: {}
 
@@ -14168,70 +8292,20 @@ snapshots:
       webidl-conversions: 7.0.0
 
   whatwg-url@7.1.0:
-=======
-    dev: true
-
-  /webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-    dev: true
-
-  /webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /whatwg-encoding@3.1.1:
-    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: true
-
-  /whatwg-mimetype@4.0.0:
-    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /whatwg-url@14.0.0:
-    resolution: {integrity: sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==}
-    engines: {node: '>=18'}
-    dependencies:
-      tr46: 5.0.0
-      webidl-conversions: 7.0.0
-    dev: true
-
-  /whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
       webidl-conversions: 4.0.2
-<<<<<<< HEAD
 
   which-boxed-primitive@1.0.2:
-=======
-    dev: true
-
-  /which-boxed-primitive@1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       is-bigint: 1.0.4
       is-boolean-object: 1.1.2
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
-<<<<<<< HEAD
 
   which-builtin-type@1.1.3:
-=======
-    dev: true
-
-  /which-builtin-type@1.1.3:
-    resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       function.prototype.name: 1.1.6
       has-tostringtag: 1.0.2
@@ -14245,38 +8319,21 @@ snapshots:
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.2
       which-typed-array: 1.1.15
-<<<<<<< HEAD
 
   which-collection@1.0.2:
-=======
-    dev: true
-
-  /which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       is-map: 2.0.3
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.3
-<<<<<<< HEAD
 
   which-typed-array@1.1.15:
-=======
-    dev: true
-
-  /which-typed-array@1.1.15:
-    resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
-    engines: {node: '>= 0.4'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.7
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.2
-<<<<<<< HEAD
 
   which@2.0.2:
     dependencies:
@@ -14285,44 +8342,16 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
-=======
-    dev: true
-
-  /which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-    dependencies:
-      isexe: 2.0.0
-
-  /word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-<<<<<<< HEAD
 
   wrap-ansi@8.1.0:
-=======
-    dev: true
-
-  /wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-<<<<<<< HEAD
 
   wrappy@1.0.2: {}
 
@@ -14346,98 +8375,3 @@ snapshots:
   yaml@2.4.3: {}
 
   yocto-queue@0.1.0: {}
-=======
-    dev: true
-
-  /wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  /write-file-atomic@4.0.2:
-    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      imurmurhash: 0.1.4
-      signal-exit: 3.0.7
-    dev: true
-
-  /ws@7.5.9:
-    resolution: {integrity: sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
-
-  /ws@8.17.0:
-    resolution: {integrity: sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
-
-  /xml-name-validator@5.0.0:
-    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
-    engines: {node: '>=18'}
-    dev: true
-
-  /xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: true
-
-  /yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-    dev: true
-
-  /yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
-
-  /yaml@2.4.3:
-    resolution: {integrity: sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==}
-    engines: {node: '>= 14'}
-    hasBin: true
-    dev: true
-
-  /yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
-    dev: true
-
-  github.com/nymlab/cosmes/f9c4e4ef3f(@bufbuild/protobuf@1.2.0)(@noble/hashes@1.4.0)(@noble/secp256k1@2.1.0)(@scure/base@1.1.6)(@scure/bip32@1.4.0)(@scure/bip39@1.3.0)(@walletconnect/legacy-client@2.0.0)(@walletconnect/sign-client@2.8.6)(lodash-es@4.17.21):
-    resolution: {tarball: https://codeload.github.com/nymlab/cosmes/tar.gz/f9c4e4ef3f}
-    id: github.com/nymlab/cosmes/f9c4e4ef3f
-    name: cosmes
-    version: 0.0.69
-    peerDependencies:
-      '@bufbuild/protobuf': 1.2.0
-      '@noble/hashes': ^1.3.2
-      '@noble/secp256k1': ^2.0.0
-      '@scure/base': ^1.1.3
-      '@scure/bip32': ^1.3.2
-      '@scure/bip39': ^1.2.1
-      '@walletconnect/legacy-client': ^2.0.0
-      '@walletconnect/sign-client': 2.8.6
-      lodash-es: ^4.17.21
-    dependencies:
-      '@bufbuild/protobuf': 1.2.0
-      '@noble/hashes': 1.4.0
-      '@noble/secp256k1': 2.1.0
-      '@scure/base': 1.1.6
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      '@walletconnect/legacy-client': 2.0.0
-      '@walletconnect/sign-client': 2.8.6
-      lodash-es: 4.17.21
-    dev: false
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)

--- a/avida-ts/scripts/deploy-avida.mjs
+++ b/avida-ts/scripts/deploy-avida.mjs
@@ -1,3 +1,0 @@
-import { main } from "@avida-ts/deployer";
-
-main();

--- a/avida-ts/scripts/gen-contract-types.mjs
+++ b/avida-ts/scripts/gen-contract-types.mjs
@@ -8,15 +8,6 @@
 
 import codegen from "@cosmwasm/ts-codegen";
 import fs from "fs";
-=======
- * repos specified in `REPOS`. It uses `buf` to generate TS files from the proto
- * files, and then generates an `index.ts` file to re-export the generated code.
- */
-
-import { default as codegen } from "@cosmwasm/ts-codegen";
-import fs from "fs";
-import { mkdirSync } from "fs";
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
@@ -36,18 +27,14 @@ const CONTRACTS = [
     path: "sdjwt-verifier",
     name: "SdjwtVerifier",
   },
-<<<<<<< HEAD
   {
     path: "avida_example",
     name: "RestaurantContract",
   },
-=======
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
 ];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONTRACT_DIR = join(__dirname, "../..", "contracts");
-<<<<<<< HEAD
 const OUT_DIR = join(
   __dirname,
   "..",
@@ -57,23 +44,15 @@ const OUT_DIR = join(
 
 // if OUT_DIR exists, remove it
 if (fs.existsSync(OUT_DIR)) fs.rmdirSync(OUT_DIR, { recursive: true });
-=======
-const OUT_DIR = join(__dirname, "..", "packages", "avida-common-types");
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
 
 console.log("CONTRACT_DIR", CONTRACT_DIR);
 console.log("OUT_DIR", OUT_DIR);
 
 console.log("Generating TS files from JSON schema files...");
 
-<<<<<<< HEAD
 // @ts-ignore: Strange  module importing
 codegen
   .default({
-=======
-{
-  await codegen.default({
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)
     contracts: CONTRACTS.map(({ path, name }) => ({
       name,
       dir: join(CONTRACT_DIR, path),
@@ -81,7 +60,6 @@ codegen
     outPath: OUT_DIR,
     options: {
       bundle: {
-<<<<<<< HEAD
         enabled: true,
         bundleFile: "contracts.ts",
       },
@@ -96,82 +74,3 @@ codegen
   .then(() => {
     console.log("Contract ts generation completed successfully!");
   });
-=======
-        enabled: false,
-      },
-      client: {
-        noImplicitOverride: true,
-      },
-      messageBuilder: {
-        enabled: true,
-      },
-    },
-  });
-}
-
-console.log("Organising output files");
-{
-  const generationTypes = ["type", "message"];
-  const files = fs.readdirSync(OUT_DIR).filter((f) => f != ".tmp");
-
-  // create directories for types and messages
-  generationTypes.map((t) => mkdirSync(join(OUT_DIR, t.concat("s"))));
-
-  for (const file of files) {
-    if (file.includes("types")) {
-      fs.renameSync(join(OUT_DIR, file), join(OUT_DIR, "types", file));
-    }
-    if (file.includes("message-builder")) updateMessageFileType(file);
-    // TODO: remove, we are not using cosmJS clients
-    if (file.includes("client")) fs.rmSync(join(OUT_DIR, file));
-  }
-
-  // Create index.ts files in  messages/, types/
-  for (const type of generationTypes) {
-    if (type === "type") {
-      let data = CONTRACTS.map(
-        ({ name }) => `import * as ${name + "Types"} from "./${name}.${type}s"`,
-      ).join("\n");
-
-      data = data.concat(
-        `\nexport { ${CONTRACTS.map(({ name }) => name + "Types").join(", ")} }`,
-      );
-      fs.writeFileSync(join(OUT_DIR, `${type}s/index.ts`), data);
-    } else {
-      const data = CONTRACTS.map(
-        ({ name }) => `export * from "./${name}.${type}"`,
-      ).join("\n");
-      fs.writeFileSync(join(OUT_DIR, `${type}s/index.ts`), data);
-    }
-  }
-
-  // Create index.ts for all
-  fs.writeFileSync(
-    join(OUT_DIR, `index.ts`),
-    `export * from "./types"\nexport * from "./messages"`,
-  );
-}
-
-/**
- * @param {string} file: the name of the file
- */
-function updateMessageFileType(file) {
-  const subdir = "messages";
-  const [name] = file.split(".");
-  const fileName = file;
-  const newFileName = fileName.replace("message-builder", "message");
-  fs.renameSync(join(OUT_DIR, file), join(OUT_DIR, subdir, newFileName));
-
-  // tscodegen assumes x.types.ts is in the same directory as the message-builder and clients
-  // However, this is not the case when we group them together
-  const fileData = fs.readFileSync(join(OUT_DIR, subdir, newFileName), "utf-8");
-  const updatedFileData = fileData.replace(
-    `./${name}.types`,
-    `../types/${name}.types`,
-  );
-
-  fs.writeFileSync(join(OUT_DIR, subdir, newFileName), updatedFileData);
-}
-
-console.log("Contract ts generation completed successfully!");
->>>>>>> b1cef2c (Change laddr to bind to 0.0.0.0 instead of 127.0.0.1 & wip: init avida-ts)

--- a/avida-ts/scripts/local-e2e-demo.mjs
+++ b/avida-ts/scripts/local-e2e-demo.mjs
@@ -31,6 +31,8 @@ export const sleep = (milliseconds) => {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 };
 
+console.log("types", avidaTypes.contracts);
+
 // ================== First we deploy the example dApp contract ==================
 // Deploy the example contract and returns contract address
 // 1. MsgStoreCode - store contract code
@@ -53,6 +55,8 @@ if (deployRes.isErr()) {
 const exampleContractAddr = deployRes.value;
 console.info("\n\n ---> Deployed example dApp at: ", exampleContractAddr);
 
+console.log(avidaTypes);
+
 // ========= Then, we use the contract registration method to register route on sdjwt-verifier ==================
 // Resource and collection id defined in the cheqd-resource-artifacts data
 // This resource was uploaded to the cheqd node in avida/avida-ts/docker/scripts/upload-cheqd-resource.sh
@@ -70,8 +74,8 @@ const req = [["age", { number: [18, "greater_than"] }]];
 
 /** @type {avidaTypes.contracts.SdjwtVerifier} */
 const routeVerificationRequirements = {
-  presentation_request: toWasmBinary(req),
-  verification_source: {
+  presentation_required: toWasmBinary(req),
+  issuer_source_or_data: {
     data_or_location: toWasmBinary(CHEQD_RESOURCE_REQ),
     source: "cheqd",
   },

--- a/contracts/avida_example/schema/avida-example.json
+++ b/contracts/avida_example/schema/avida-example.json
@@ -124,6 +124,35 @@
         },
         "additionalProperties": false
       },
+      "IssuerSourceOrData": {
+        "description": "Location to obtain the verification data from",
+        "type": "object",
+        "required": [
+          "data_or_location"
+        ],
+        "properties": {
+          "data_or_location": {
+            "description": "The data or location of the verification data at the trust registry For TrustRegistry::Cheqd, it is the `ResourceReqPacket` in avida-cheqd For data, the contracts should have the expected type In Sdjwt-Verifier, this is expected to be jwk",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          },
+          "source": {
+            "description": "If `None`, this means data is directly provided",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TrustRegistry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "RegisterRequirement": {
         "oneOf": [
           {
@@ -174,23 +203,23 @@
         "description": "Specific verification requirements for the route, by `route_id`",
         "type": "object",
         "required": [
-          "presentation_request",
-          "verification_source"
+          "issuer_source_or_data",
+          "presentation_required"
         ],
         "properties": {
-          "presentation_request": {
-            "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
-          },
-          "verification_source": {
+          "issuer_source_or_data": {
             "description": "This defines where the source data for verification is",
             "allOf": [
               {
-                "$ref": "#/definitions/VerificationSource"
+                "$ref": "#/definitions/IssuerSourceOrData"
+              }
+            ]
+          },
+          "presentation_required": {
+            "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
               }
             ]
           }
@@ -202,35 +231,6 @@
         "enum": [
           "cheqd"
         ]
-      },
-      "VerificationSource": {
-        "description": "Location to obtain the verification data from",
-        "type": "object",
-        "required": [
-          "data_or_location"
-        ],
-        "properties": {
-          "data_or_location": {
-            "description": "The data or location of the verification data at the trust registry For TrustRegistry::Cheqd, it is the `ResourceReqPacket` in avida-cheqd For data, the contracts should have the expected type In Sdjwt-Verifier, this is expected to be jwk",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
-          },
-          "source": {
-            "description": "If `None`, this means data is directly provided",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/TrustRegistry"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
       }
     }
   },
@@ -292,23 +292,23 @@
       "description": "Specific verification requirements for the route, by `route_id`",
       "type": "object",
       "required": [
-        "presentation_request",
-        "verification_source"
+        "issuer_source_or_data",
+        "presentation_required"
       ],
       "properties": {
-        "presentation_request": {
-          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        },
-        "verification_source": {
+        "issuer_source_or_data": {
           "description": "This defines where the source data for verification is",
           "allOf": [
             {
-              "$ref": "#/definitions/VerificationSource"
+              "$ref": "#/definitions/IssuerSourceOrData"
+            }
+          ]
+        },
+        "presentation_required": {
+          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
             }
           ]
         }
@@ -319,13 +319,7 @@
           "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
           "type": "string"
         },
-        "TrustRegistry": {
-          "type": "string",
-          "enum": [
-            "cheqd"
-          ]
-        },
-        "VerificationSource": {
+        "IssuerSourceOrData": {
           "description": "Location to obtain the verification data from",
           "type": "object",
           "required": [
@@ -353,6 +347,12 @@
             }
           },
           "additionalProperties": false
+        },
+        "TrustRegistry": {
+          "type": "string",
+          "enum": [
+            "cheqd"
+          ]
         }
       }
     },

--- a/contracts/avida_example/schema/avida-example.json
+++ b/contracts/avida_example/schema/avida-example.json
@@ -256,28 +256,6 @@
               }
             },
             "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "get_route_requirements"
-            ],
-            "properties": {
-              "get_route_requirements": {
-                "type": "object",
-                "required": [
-                  "route_id"
-                ],
-                "properties": {
-                  "route_id": {
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
           }
         ]
       }
@@ -286,76 +264,6 @@
   "migrate": null,
   "sudo": null,
   "responses": {
-    "get_route_requirements": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "RouteVerificationRequirements",
-      "description": "Specific verification requirements for the route, by `route_id`",
-      "type": "object",
-      "required": [
-        "issuer_source_or_data",
-        "presentation_required"
-      ],
-      "properties": {
-        "issuer_source_or_data": {
-          "description": "This defines where the source data for verification is",
-          "allOf": [
-            {
-              "$ref": "#/definitions/IssuerSourceOrData"
-            }
-          ]
-        },
-        "presentation_required": {
-          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "definitions": {
-        "Binary": {
-          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-          "type": "string"
-        },
-        "IssuerSourceOrData": {
-          "description": "Location to obtain the verification data from",
-          "type": "object",
-          "required": [
-            "data_or_location"
-          ],
-          "properties": {
-            "data_or_location": {
-              "description": "The data or location of the verification data at the trust registry For TrustRegistry::Cheqd, it is the `ResourceReqPacket` in avida-cheqd For data, the contracts should have the expected type In Sdjwt-Verifier, this is expected to be jwk",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Binary"
-                }
-              ]
-            },
-            "source": {
-              "description": "If `None`, this means data is directly provided",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TrustRegistry"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
-        "TrustRegistry": {
-          "type": "string",
-          "enum": [
-            "cheqd"
-          ]
-        }
-      }
-    },
     "get_verifier_address": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "GetVerifierResponse",

--- a/contracts/avida_example/schema/raw/execute.json
+++ b/contracts/avida_example/schema/raw/execute.json
@@ -107,6 +107,35 @@
       },
       "additionalProperties": false
     },
+    "IssuerSourceOrData": {
+      "description": "Location to obtain the verification data from",
+      "type": "object",
+      "required": [
+        "data_or_location"
+      ],
+      "properties": {
+        "data_or_location": {
+          "description": "The data or location of the verification data at the trust registry For TrustRegistry::Cheqd, it is the `ResourceReqPacket` in avida-cheqd For data, the contracts should have the expected type In Sdjwt-Verifier, this is expected to be jwk",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        },
+        "source": {
+          "description": "If `None`, this means data is directly provided",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TrustRegistry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "RegisterRequirement": {
       "oneOf": [
         {
@@ -157,23 +186,23 @@
       "description": "Specific verification requirements for the route, by `route_id`",
       "type": "object",
       "required": [
-        "presentation_request",
-        "verification_source"
+        "issuer_source_or_data",
+        "presentation_required"
       ],
       "properties": {
-        "presentation_request": {
-          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        },
-        "verification_source": {
+        "issuer_source_or_data": {
           "description": "This defines where the source data for verification is",
           "allOf": [
             {
-              "$ref": "#/definitions/VerificationSource"
+              "$ref": "#/definitions/IssuerSourceOrData"
+            }
+          ]
+        },
+        "presentation_required": {
+          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
             }
           ]
         }
@@ -185,35 +214,6 @@
       "enum": [
         "cheqd"
       ]
-    },
-    "VerificationSource": {
-      "description": "Location to obtain the verification data from",
-      "type": "object",
-      "required": [
-        "data_or_location"
-      ],
-      "properties": {
-        "data_or_location": {
-          "description": "The data or location of the verification data at the trust registry For TrustRegistry::Cheqd, it is the `ResourceReqPacket` in avida-cheqd For data, the contracts should have the expected type In Sdjwt-Verifier, this is expected to be jwk",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        },
-        "source": {
-          "description": "If `None`, this means data is directly provided",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TrustRegistry"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
     }
   }
 }

--- a/contracts/avida_example/schema/raw/query.json
+++ b/contracts/avida_example/schema/raw/query.json
@@ -20,28 +20,6 @@
             }
           },
           "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "get_route_requirements"
-          ],
-          "properties": {
-            "get_route_requirements": {
-              "type": "object",
-              "required": [
-                "route_id"
-              ],
-              "properties": {
-                "route_id": {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
         }
       ]
     }

--- a/contracts/avida_example/schema/raw/response_to_get_route_requirements.json
+++ b/contracts/avida_example/schema/raw/response_to_get_route_requirements.json
@@ -4,23 +4,23 @@
   "description": "Specific verification requirements for the route, by `route_id`",
   "type": "object",
   "required": [
-    "presentation_request",
-    "verification_source"
+    "issuer_source_or_data",
+    "presentation_required"
   ],
   "properties": {
-    "presentation_request": {
-      "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Binary"
-        }
-      ]
-    },
-    "verification_source": {
+    "issuer_source_or_data": {
       "description": "This defines where the source data for verification is",
       "allOf": [
         {
-          "$ref": "#/definitions/VerificationSource"
+          "$ref": "#/definitions/IssuerSourceOrData"
+        }
+      ]
+    },
+    "presentation_required": {
+      "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Binary"
         }
       ]
     }
@@ -31,13 +31,7 @@
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
     },
-    "TrustRegistry": {
-      "type": "string",
-      "enum": [
-        "cheqd"
-      ]
-    },
-    "VerificationSource": {
+    "IssuerSourceOrData": {
       "description": "Location to obtain the verification data from",
       "type": "object",
       "required": [
@@ -65,6 +59,12 @@
         }
       },
       "additionalProperties": false
+    },
+    "TrustRegistry": {
+      "type": "string",
+      "enum": [
+        "cheqd"
+      ]
     }
   }
 }

--- a/contracts/avida_example/src/constants.rs
+++ b/contracts/avida_example/src/constants.rs
@@ -2,7 +2,6 @@ use avida_common::types::RouteId;
 
 // Route id = 1
 pub const REGISTER_REQUIREMENT_REPLY_ID: RouteId = 1u64;
-
 // Route id = 100
 pub const GIVE_ME_DRINK_ROUTE_ID: RouteId = 100u64;
 // Route id = 101

--- a/contracts/avida_example/src/contract.rs
+++ b/contracts/avida_example/src/contract.rs
@@ -94,6 +94,7 @@ impl RestaurantContract<'_> {
             presentation: msg.proof,
             route_id: GIVE_ME_DRINK_ROUTE_ID,
             app_addr: Some(ctx.env.contract.address.to_string()),
+            additional_requirements: None,
         };
         let sub_msg = SubMsg::reply_always(
             WasmMsg::Execute {
@@ -123,6 +124,7 @@ impl RestaurantContract<'_> {
             presentation: msg.proof,
             route_id: GIVE_ME_FOOD_ROUTE_ID,
             app_addr: Some(ctx.env.contract.address.to_string()),
+            additional_requirements: None,
         };
 
         let sub_msg = SubMsg::reply_always(

--- a/contracts/avida_example/src/contract.rs
+++ b/contracts/avida_example/src/contract.rs
@@ -1,5 +1,5 @@
 use avida_common::traits::avida_verifier_trait::sv::{AvidaVerifierTraitExecMsg, Querier};
-use avida_common::types::{InputRoutesRequirements, RouteId, RouteVerificationRequirements};
+use avida_common::types::{RegisterRouteRequest, RouteId, RouteVerificationRequirements};
 
 use avida_sdjwt_verifier::{contract::SdjwtVerifier, types::VerifyResult};
 use sylvia::cw_std::{from_json, Reply, Response, StdResult, SubMsg};
@@ -47,12 +47,12 @@ impl RestaurantContract<'_> {
         ctx: sylvia::types::ExecCtx,
         msg: RegisterRequirement,
     ) -> StdResult<Response> {
-        let route_requirements: InputRoutesRequirements = match msg {
-            RegisterRequirement::Drink { requirements } => InputRoutesRequirements {
+        let route_requirements: RegisterRouteRequest = match msg {
+            RegisterRequirement::Drink { requirements } => RegisterRouteRequest {
                 route_id: GIVE_ME_DRINK_ROUTE_ID,
                 requirements,
             },
-            RegisterRequirement::Food { requirements } => InputRoutesRequirements {
+            RegisterRequirement::Food { requirements } => RegisterRouteRequest {
                 route_id: GIVE_ME_FOOD_ROUTE_ID,
                 requirements,
             },
@@ -60,7 +60,7 @@ impl RestaurantContract<'_> {
 
         let register_msg = AvidaVerifierTraitExecMsg::Register {
             app_addr: ctx.env.contract.address.to_string(),
-            route_criteria: vec![route_requirements],
+            requests: vec![route_requirements],
         };
 
         let verifier_contract = self.verifier.load(ctx.deps.storage)?;

--- a/contracts/avida_example/src/error.rs
+++ b/contracts/avida_example/src/error.rs
@@ -1,5 +1,4 @@
 use cosmwasm_std::StdError;
-use cw_utils::ParseReplyError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -7,8 +6,8 @@ pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
 
-    #[error("Parse Reply Error {0}")]
-    ParseReplyError(#[from] ParseReplyError),
+    #[error("Parse Reply Error")]
+    ParseReplyError,
 
     #[error("Registration Error {0}")]
     RegistrationError(String),

--- a/contracts/avida_example/src/tests/exec_test.rs
+++ b/contracts/avida_example/src/tests/exec_test.rs
@@ -51,13 +51,13 @@ fn register_requirement() {
         .unwrap();
 
     assert_eq!(
-        registered_req.verification_source,
-        fx_route_verification_req.verification_source
+        registered_req.issuer_source_or_data,
+        fx_route_verification_req.issuer_source_or_data
     );
 
     assert_eq!(
-        registered_req.presentation_request,
-        fx_route_verification_req.presentation_request
+        registered_req.presentation_required,
+        fx_route_verification_req.presentation_required
     );
 
     let route_verification_key = contract_verifier

--- a/contracts/avida_example/src/tests/query_test.rs
+++ b/contracts/avida_example/src/tests/query_test.rs
@@ -1,13 +1,9 @@
 use cosmwasm_std::Addr;
 use sylvia::multitest::App;
 
-use avida_sdjwt_verifier::contract::sv::mt::CodeId as VerifierCodeID;
 use avida_test_utils::sdjwt::fixtures::OWNER_ADDR;
 
-use crate::constants::GIVE_ME_DRINK_ROUTE_ID;
 use crate::contract::sv::mt::{CodeId as RestaurantCodeID, RestaurantContractProxy};
-use crate::tests::fixtures::setup_requirement;
-use crate::types::RegisterRequirement;
 
 #[test]
 fn get_verifier() {
@@ -25,37 +21,37 @@ fn get_verifier() {
     assert_eq!(asked_verifier.verifier, verifier_contract_addr);
 }
 
-#[test]
-fn get_route_requirements() {
-    let app = App::default();
-    // Storages for contracts
-    let code_id_verifier = VerifierCodeID::store_code(&app);
-    let code_id_restaurant = RestaurantCodeID::store_code(&app);
-
-    // Instantiate contracts
-    let max_presentation_len = 3000usize;
-    let contract_verifier = code_id_verifier
-        .instantiate(max_presentation_len, vec![])
-        .with_label("Verifier")
-        .call(OWNER_ADDR)
-        .unwrap();
-
-    let contract_restaurant = code_id_restaurant
-        .instantiate(contract_verifier.contract_addr.to_string())
-        .with_label("Restaurant")
-        .call(OWNER_ADDR)
-        .unwrap();
-    // Setup requirement
-    let fx_route_verification_req = setup_requirement("drink");
-    contract_restaurant
-        .register_requirement(RegisterRequirement::Drink {
-            requirements: fx_route_verification_req.clone(),
-        })
-        .call(OWNER_ADDR)
-        .unwrap();
-    let registered_routes = contract_restaurant
-        .get_route_requirements(GIVE_ME_DRINK_ROUTE_ID)
-        .unwrap();
-
-    assert_eq!(registered_routes, fx_route_verification_req);
-}
+//#[test]
+//fn get_route_requirements() {
+//    let app = App::default();
+//    // Storages for contracts
+//    let code_id_verifier = VerifierCodeID::store_code(&app);
+//    let code_id_restaurant = RestaurantCodeID::store_code(&app);
+//
+//    // Instantiate contracts
+//    let max_presentation_len = 3000usize;
+//    let contract_verifier = code_id_verifier
+//        .instantiate(max_presentation_len, vec![])
+//        .with_label("Verifier")
+//        .call(OWNER_ADDR)
+//        .unwrap();
+//
+//    let contract_restaurant = code_id_restaurant
+//        .instantiate(contract_verifier.contract_addr.to_string())
+//        .with_label("Restaurant")
+//        .call(OWNER_ADDR)
+//        .unwrap();
+//    // Setup requirement
+//    let fx_route_verification_req = setup_requirement("drink");
+//    contract_restaurant
+//        .register_requirement(RegisterRequirement::Drink {
+//            requirements: fx_route_verification_req.clone(),
+//        })
+//        .call(OWNER_ADDR)
+//        .unwrap();
+//    let registered_routes = contract_restaurant
+//        .get_route_requirements(GIVE_ME_DRINK_ROUTE_ID)
+//        .unwrap();
+//
+//    assert_eq!(registered_routes, fx_route_verification_req);
+//}

--- a/contracts/sdjwt-verifier/schema/avida-sdjwt-verifier.json
+++ b/contracts/sdjwt-verifier/schema/avida-sdjwt-verifier.json
@@ -45,65 +45,13 @@
           "routes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/InputRoutesRequirements"
+              "$ref": "#/definitions/RegisterRouteRequest"
             }
           }
         },
         "additionalProperties": false
       },
-      "InputRoutesRequirements": {
-        "description": "Routes Requiments used in Registration (and Initiation)",
-        "type": "object",
-        "required": [
-          "requirements",
-          "route_id"
-        ],
-        "properties": {
-          "requirements": {
-            "$ref": "#/definitions/RouteVerificationRequirements"
-          },
-          "route_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        },
-        "additionalProperties": false
-      },
-      "RouteVerificationRequirements": {
-        "description": "Specific verification requirements for the route, by `route_id`",
-        "type": "object",
-        "required": [
-          "presentation_request",
-          "verification_source"
-        ],
-        "properties": {
-          "presentation_request": {
-            "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
-          },
-          "verification_source": {
-            "description": "This defines where the source data for verification is",
-            "allOf": [
-              {
-                "$ref": "#/definitions/VerificationSource"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "TrustRegistry": {
-        "type": "string",
-        "enum": [
-          "cheqd"
-        ]
-      },
-      "VerificationSource": {
+      "IssuerSourceOrData": {
         "description": "Location to obtain the verification data from",
         "type": "object",
         "required": [
@@ -131,6 +79,58 @@
           }
         },
         "additionalProperties": false
+      },
+      "RegisterRouteRequest": {
+        "description": "Routes Requiments used in Registration (and Initiation)",
+        "type": "object",
+        "required": [
+          "requirements",
+          "route_id"
+        ],
+        "properties": {
+          "requirements": {
+            "$ref": "#/definitions/RouteVerificationRequirements"
+          },
+          "route_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "RouteVerificationRequirements": {
+        "description": "Specific verification requirements for the route, by `route_id`",
+        "type": "object",
+        "required": [
+          "issuer_source_or_data",
+          "presentation_required"
+        ],
+        "properties": {
+          "issuer_source_or_data": {
+            "description": "This defines where the source data for verification is",
+            "allOf": [
+              {
+                "$ref": "#/definitions/IssuerSourceOrData"
+              }
+            ]
+          },
+          "presentation_required": {
+            "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrustRegistry": {
+        "type": "string",
+        "enum": [
+          "cheqd"
+        ]
       }
     }
   },
@@ -158,16 +158,16 @@
                 "type": "object",
                 "required": [
                   "app_addr",
-                  "route_criteria"
+                  "requests"
                 ],
                 "properties": {
                   "app_addr": {
                     "type": "string"
                   },
-                  "route_criteria": {
+                  "requests": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/definitions/InputRoutesRequirements"
+                      "$ref": "#/definitions/RegisterRouteRequest"
                     }
                   }
                 }
@@ -188,6 +188,16 @@
                   "route_id"
                 ],
                 "properties": {
+                  "additional_requirements": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "app_addr": {
                     "type": [
                       "string",
@@ -270,62 +280,34 @@
         "type": "string"
       },
       "ExecMsg": {
-        "type": "string",
-        "enum": []
-      },
-      "InputRoutesRequirements": {
-        "description": "Routes Requiments used in Registration (and Initiation)",
-        "type": "object",
-        "required": [
-          "requirements",
-          "route_id"
-        ],
-        "properties": {
-          "requirements": {
-            "$ref": "#/definitions/RouteVerificationRequirements"
-          },
-          "route_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        },
-        "additionalProperties": false
-      },
-      "RouteVerificationRequirements": {
-        "description": "Specific verification requirements for the route, by `route_id`",
-        "type": "object",
-        "required": [
-          "presentation_request",
-          "verification_source"
-        ],
-        "properties": {
-          "presentation_request": {
-            "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "update_revocation_list"
+            ],
+            "properties": {
+              "update_revocation_list": {
+                "type": "object",
+                "required": [
+                  "app_addr",
+                  "request"
+                ],
+                "properties": {
+                  "app_addr": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "$ref": "#/definitions/UpdateRevocationListRequest"
+                  }
+                }
               }
-            ]
-          },
-          "verification_source": {
-            "description": "This defines where the source data for verification is",
-            "allOf": [
-              {
-                "$ref": "#/definitions/VerificationSource"
-              }
-            ]
+            },
+            "additionalProperties": false
           }
-        },
-        "additionalProperties": false
-      },
-      "TrustRegistry": {
-        "type": "string",
-        "enum": [
-          "cheqd"
         ]
       },
-      "VerificationSource": {
+      "IssuerSourceOrData": {
         "description": "Location to obtain the verification data from",
         "type": "object",
         "required": [
@@ -350,6 +332,91 @@
                 "type": "null"
               }
             ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "RegisterRouteRequest": {
+        "description": "Routes Requiments used in Registration (and Initiation)",
+        "type": "object",
+        "required": [
+          "requirements",
+          "route_id"
+        ],
+        "properties": {
+          "requirements": {
+            "$ref": "#/definitions/RouteVerificationRequirements"
+          },
+          "route_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "RouteVerificationRequirements": {
+        "description": "Specific verification requirements for the route, by `route_id`",
+        "type": "object",
+        "required": [
+          "issuer_source_or_data",
+          "presentation_required"
+        ],
+        "properties": {
+          "issuer_source_or_data": {
+            "description": "This defines where the source data for verification is",
+            "allOf": [
+              {
+                "$ref": "#/definitions/IssuerSourceOrData"
+              }
+            ]
+          },
+          "presentation_required": {
+            "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrustRegistry": {
+        "type": "string",
+        "enum": [
+          "cheqd"
+        ]
+      },
+      "UpdateRevocationListRequest": {
+        "description": "A Sd-jwt specific requirement for revocation list update using Criterion::NotContainedIn",
+        "type": "object",
+        "required": [
+          "revoke",
+          "route_id",
+          "unrevoke"
+        ],
+        "properties": {
+          "revoke": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "route_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "unrevoke": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
           }
         },
         "additionalProperties": false
@@ -459,23 +526,23 @@
       "description": "Specific verification requirements for the route, by `route_id`",
       "type": "object",
       "required": [
-        "presentation_request",
-        "verification_source"
+        "issuer_source_or_data",
+        "presentation_required"
       ],
       "properties": {
-        "presentation_request": {
-          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        },
-        "verification_source": {
+        "issuer_source_or_data": {
           "description": "This defines where the source data for verification is",
           "allOf": [
             {
-              "$ref": "#/definitions/VerificationSource"
+              "$ref": "#/definitions/IssuerSourceOrData"
+            }
+          ]
+        },
+        "presentation_required": {
+          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
             }
           ]
         }
@@ -486,13 +553,7 @@
           "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
           "type": "string"
         },
-        "TrustRegistry": {
-          "type": "string",
-          "enum": [
-            "cheqd"
-          ]
-        },
-        "VerificationSource": {
+        "IssuerSourceOrData": {
           "description": "Location to obtain the verification data from",
           "type": "object",
           "required": [
@@ -520,6 +581,12 @@
             }
           },
           "additionalProperties": false
+        },
+        "TrustRegistry": {
+          "type": "string",
+          "enum": [
+            "cheqd"
+          ]
         }
       }
     },

--- a/contracts/sdjwt-verifier/schema/raw/execute.json
+++ b/contracts/sdjwt-verifier/schema/raw/execute.json
@@ -22,16 +22,16 @@
               "type": "object",
               "required": [
                 "app_addr",
-                "route_criteria"
+                "requests"
               ],
               "properties": {
                 "app_addr": {
                   "type": "string"
                 },
-                "route_criteria": {
+                "requests": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/InputRoutesRequirements"
+                    "$ref": "#/definitions/RegisterRouteRequest"
                   }
                 }
               }
@@ -52,6 +52,16 @@
                 "route_id"
               ],
               "properties": {
+                "additional_requirements": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "app_addr": {
                   "type": [
                     "string",
@@ -134,62 +144,34 @@
       "type": "string"
     },
     "ExecMsg": {
-      "type": "string",
-      "enum": []
-    },
-    "InputRoutesRequirements": {
-      "description": "Routes Requiments used in Registration (and Initiation)",
-      "type": "object",
-      "required": [
-        "requirements",
-        "route_id"
-      ],
-      "properties": {
-        "requirements": {
-          "$ref": "#/definitions/RouteVerificationRequirements"
-        },
-        "route_id": {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      },
-      "additionalProperties": false
-    },
-    "RouteVerificationRequirements": {
-      "description": "Specific verification requirements for the route, by `route_id`",
-      "type": "object",
-      "required": [
-        "presentation_request",
-        "verification_source"
-      ],
-      "properties": {
-        "presentation_request": {
-          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "update_revocation_list"
+          ],
+          "properties": {
+            "update_revocation_list": {
+              "type": "object",
+              "required": [
+                "app_addr",
+                "request"
+              ],
+              "properties": {
+                "app_addr": {
+                  "type": "string"
+                },
+                "request": {
+                  "$ref": "#/definitions/UpdateRevocationListRequest"
+                }
+              }
             }
-          ]
-        },
-        "verification_source": {
-          "description": "This defines where the source data for verification is",
-          "allOf": [
-            {
-              "$ref": "#/definitions/VerificationSource"
-            }
-          ]
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
-    },
-    "TrustRegistry": {
-      "type": "string",
-      "enum": [
-        "cheqd"
       ]
     },
-    "VerificationSource": {
+    "IssuerSourceOrData": {
       "description": "Location to obtain the verification data from",
       "type": "object",
       "required": [
@@ -214,6 +196,91 @@
               "type": "null"
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "RegisterRouteRequest": {
+      "description": "Routes Requiments used in Registration (and Initiation)",
+      "type": "object",
+      "required": [
+        "requirements",
+        "route_id"
+      ],
+      "properties": {
+        "requirements": {
+          "$ref": "#/definitions/RouteVerificationRequirements"
+        },
+        "route_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "RouteVerificationRequirements": {
+      "description": "Specific verification requirements for the route, by `route_id`",
+      "type": "object",
+      "required": [
+        "issuer_source_or_data",
+        "presentation_required"
+      ],
+      "properties": {
+        "issuer_source_or_data": {
+          "description": "This defines where the source data for verification is",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IssuerSourceOrData"
+            }
+          ]
+        },
+        "presentation_required": {
+          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TrustRegistry": {
+      "type": "string",
+      "enum": [
+        "cheqd"
+      ]
+    },
+    "UpdateRevocationListRequest": {
+      "description": "A Sd-jwt specific requirement for revocation list update using Criterion::NotContainedIn",
+      "type": "object",
+      "required": [
+        "revoke",
+        "route_id",
+        "unrevoke"
+      ],
+      "properties": {
+        "revoke": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "route_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "unrevoke": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/sdjwt-verifier/schema/raw/instantiate.json
+++ b/contracts/sdjwt-verifier/schema/raw/instantiate.json
@@ -41,65 +41,13 @@
         "routes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/InputRoutesRequirements"
+            "$ref": "#/definitions/RegisterRouteRequest"
           }
         }
       },
       "additionalProperties": false
     },
-    "InputRoutesRequirements": {
-      "description": "Routes Requiments used in Registration (and Initiation)",
-      "type": "object",
-      "required": [
-        "requirements",
-        "route_id"
-      ],
-      "properties": {
-        "requirements": {
-          "$ref": "#/definitions/RouteVerificationRequirements"
-        },
-        "route_id": {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      },
-      "additionalProperties": false
-    },
-    "RouteVerificationRequirements": {
-      "description": "Specific verification requirements for the route, by `route_id`",
-      "type": "object",
-      "required": [
-        "presentation_request",
-        "verification_source"
-      ],
-      "properties": {
-        "presentation_request": {
-          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        },
-        "verification_source": {
-          "description": "This defines where the source data for verification is",
-          "allOf": [
-            {
-              "$ref": "#/definitions/VerificationSource"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "TrustRegistry": {
-      "type": "string",
-      "enum": [
-        "cheqd"
-      ]
-    },
-    "VerificationSource": {
+    "IssuerSourceOrData": {
       "description": "Location to obtain the verification data from",
       "type": "object",
       "required": [
@@ -127,6 +75,58 @@
         }
       },
       "additionalProperties": false
+    },
+    "RegisterRouteRequest": {
+      "description": "Routes Requiments used in Registration (and Initiation)",
+      "type": "object",
+      "required": [
+        "requirements",
+        "route_id"
+      ],
+      "properties": {
+        "requirements": {
+          "$ref": "#/definitions/RouteVerificationRequirements"
+        },
+        "route_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "RouteVerificationRequirements": {
+      "description": "Specific verification requirements for the route, by `route_id`",
+      "type": "object",
+      "required": [
+        "issuer_source_or_data",
+        "presentation_required"
+      ],
+      "properties": {
+        "issuer_source_or_data": {
+          "description": "This defines where the source data for verification is",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IssuerSourceOrData"
+            }
+          ]
+        },
+        "presentation_required": {
+          "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TrustRegistry": {
+      "type": "string",
+      "enum": [
+        "cheqd"
+      ]
     }
   }
 }

--- a/contracts/sdjwt-verifier/schema/raw/response_to_get_route_requirements.json
+++ b/contracts/sdjwt-verifier/schema/raw/response_to_get_route_requirements.json
@@ -4,23 +4,23 @@
   "description": "Specific verification requirements for the route, by `route_id`",
   "type": "object",
   "required": [
-    "presentation_request",
-    "verification_source"
+    "issuer_source_or_data",
+    "presentation_required"
   ],
   "properties": {
-    "presentation_request": {
-      "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Binary"
-        }
-      ]
-    },
-    "verification_source": {
+    "issuer_source_or_data": {
       "description": "This defines where the source data for verification is",
       "allOf": [
         {
-          "$ref": "#/definitions/VerificationSource"
+          "$ref": "#/definitions/IssuerSourceOrData"
+        }
+      ]
+    },
+    "presentation_required": {
+      "description": "The presentation request is the criteria required for the presentation, for example required certains claims to be disclosed This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Binary"
         }
       ]
     }
@@ -31,13 +31,7 @@
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
     },
-    "TrustRegistry": {
-      "type": "string",
-      "enum": [
-        "cheqd"
-      ]
-    },
-    "VerificationSource": {
+    "IssuerSourceOrData": {
       "description": "Location to obtain the verification data from",
       "type": "object",
       "required": [
@@ -65,6 +59,12 @@
         }
       },
       "additionalProperties": false
+    },
+    "TrustRegistry": {
+      "type": "string",
+      "enum": [
+        "cheqd"
+      ]
     }
   }
 }

--- a/contracts/sdjwt-verifier/src/contract.rs
+++ b/contracts/sdjwt-verifier/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::SdjwtVerifierError,
-    types::{InitRegistration, PendingRoute, VerificationReq},
+    types::{InitRegistration, PendingRoute, VerificationRequirements},
 };
 
 // AVIDA specific
@@ -9,7 +9,7 @@ use avida_cheqd::ibc::{
 };
 use avida_common::{
     traits::avida_verifier_trait,
-    types::{MaxPresentationLen, RouteId, VerificationSource, MAX_PRESENTATION_LEN},
+    types::{IssuerSourceOrData, MaxPresentationLen, RouteId, MAX_PRESENTATION_LEN},
 };
 //  CosmWasm / Sylvia lib
 use cosmwasm_std::{
@@ -37,8 +37,11 @@ pub struct SdjwtVerifier<'a> {
     /// Max Presentation Length
     pub max_presentation_len: MaxPresentationLen<'a>,
     /// Registered Smart Contract addrs and routes
-    pub app_trust_data_source: Map<'a, &'a str, HashMap<RouteId, VerificationSource>>,
-    pub app_routes_requirements: Map<'a, &'a str, HashMap<RouteId, VerificationReq>>,
+    pub app_trust_data_source: Map<'a, &'a str, HashMap<RouteId, IssuerSourceOrData>>,
+    /// Per route, the requirements that is required for verifier to make a decision
+    /// This contains the presentation required (i.e. disclosed value requirements) and the issuer
+    /// pubkey
+    pub app_routes_requirements: Map<'a, &'a str, HashMap<RouteId, VerificationRequirements>>,
     /// Registered Smart Contract addrs and their admins
     pub app_admins: Map<'a, &'a str, Addr>,
     /// The IBC channel connecting with cheqd resource

--- a/contracts/sdjwt-verifier/src/errors.rs
+++ b/contracts/sdjwt-verifier/src/errors.rs
@@ -52,6 +52,10 @@ pub enum SdjwtVerifierError {
     RouteNotRegistered,
     #[error("No Requirements For Route")]
     NoRequirementsForRoute,
+    #[error("IDX Not In Requirement")]
+    IDXNotInRequirement,
+    #[error("Revocation List type")]
+    RevocationListType,
 }
 
 impl From<SdjwtVerifierError> for StdError {

--- a/contracts/sdjwt-verifier/src/errors.rs
+++ b/contracts/sdjwt-verifier/src/errors.rs
@@ -20,6 +20,7 @@ pub enum SdjwtVerifierResultError {
     ExpirationStringInvalid(String),
     ExpirationKeyOrValueInvalid(String, String),
     PresentationExpired(cw_utils::Expiration),
+    IdxRevoked(u64),
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/contracts/sdjwt-verifier/src/tests/contract_test.rs
+++ b/contracts/sdjwt-verifier/src/tests/contract_test.rs
@@ -1,0 +1,102 @@
+use cosmwasm_std::{from_json, Binary};
+
+use sylvia::multitest::App;
+
+use crate::contract::sv::mt::SdjwtVerifierProxy;
+use crate::types::{Criterion, PresentationReq};
+use avida_common::traits::avida_verifier_trait::sv::mt::AvidaVerifierTraitProxy;
+use serde::{Deserialize, Serialize};
+
+use super::fixtures::instantiate_verifier_contract;
+use avida_test_utils::sdjwt::fixtures::{
+    claims, get_default_block_info, get_input_route_requirement,
+    get_route_requirement_with_empty_revocation_list, get_route_verification_requirement,
+    get_two_input_routes_requirements, issuer_jwk, make_presentation, ExpirationCheck,
+    PresentationVerificationType, RouteVerificationRequirementsType, FIRST_CALLER_APP_ADDR,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub idx: u64,
+}
+
+const REVOCATION_ROUTE_ID: u64 = 100;
+const REVOCATION_TEST_CALLER: &str = "revocation_test_caller";
+
+#[test]
+fn test_update_revocation_list() {
+    let app: App<_> = App::default();
+
+    let (contract, _) =
+        instantiate_verifier_contract(&app, RouteVerificationRequirementsType::Supported);
+
+    // Get route verification requirements for a single route with expiration
+    let route_verification_req =
+        get_route_requirement_with_empty_revocation_list(REVOCATION_ROUTE_ID);
+
+    //Register the app with exp requirements
+    contract
+        .register(
+            REVOCATION_TEST_CALLER.to_string(),
+            vec![route_verification_req.clone()],
+        )
+        .call(REVOCATION_TEST_CALLER)
+        .unwrap();
+
+    let req: PresentationReq = from_json(
+        contract
+            .get_route_requirements(REVOCATION_TEST_CALLER.to_string(), REVOCATION_ROUTE_ID)
+            .unwrap()
+            .presentation_required,
+    )
+    .unwrap();
+
+    let revocation_list = req.iter().find(|(k, _)| k == "idx").unwrap();
+    assert_eq!(revocation_list.1, Criterion::NotContainedIn(vec![]));
+
+    contract
+        .update_revocation_list(
+            REVOCATION_TEST_CALLER.to_string(),
+            crate::types::UpdateRevocationListRequest {
+                route_id: REVOCATION_ROUTE_ID,
+                revoke: vec![1, 2, 3],
+                unrevoke: vec![4, 5],
+            },
+        )
+        .call(REVOCATION_TEST_CALLER)
+        .unwrap();
+
+    let req: PresentationReq = from_json(
+        contract
+            .get_route_requirements(REVOCATION_TEST_CALLER.to_string(), REVOCATION_ROUTE_ID)
+            .unwrap()
+            .presentation_required,
+    )
+    .unwrap();
+
+    let revocation_list = req.iter().find(|(k, _)| k == "idx").unwrap();
+    assert_eq!(revocation_list.1, Criterion::NotContainedIn(vec![1, 2, 3]));
+
+    contract
+        .update_revocation_list(
+            REVOCATION_TEST_CALLER.to_string(),
+            crate::types::UpdateRevocationListRequest {
+                route_id: REVOCATION_ROUTE_ID,
+                revoke: vec![7, 1, 7],
+                unrevoke: vec![2, 5],
+            },
+        )
+        .call(REVOCATION_TEST_CALLER)
+        .unwrap();
+
+    let req: PresentationReq = from_json(
+        contract
+            .get_route_requirements(REVOCATION_TEST_CALLER.to_string(), REVOCATION_ROUTE_ID)
+            .unwrap()
+            .presentation_required,
+    )
+    .unwrap();
+
+    let revocation_list = req.iter().find(|(k, _)| k == "idx").unwrap();
+    assert_eq!(revocation_list.1, Criterion::NotContainedIn(vec![1, 3, 7]));
+}

--- a/contracts/sdjwt-verifier/src/tests/contract_test.rs
+++ b/contracts/sdjwt-verifier/src/tests/contract_test.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{from_json, Binary};
+use cosmwasm_std::{from_json, to_json_binary, Binary};
 
 use sylvia::multitest::App;
 
@@ -12,7 +12,7 @@ use super::fixtures::instantiate_verifier_contract;
 use avida_test_utils::sdjwt::fixtures::{
     claims_with_revocation_idx, get_route_requirement_with_empty_revocation_list,
     make_presentation, PresentationVerificationType, RouteVerificationRequirementsType,
-    FIRST_CALLER_APP_ADDR,
+    FIRST_CALLER_APP_ADDR, FIRST_ROUTE_ID,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -153,6 +153,7 @@ fn test_revoked_presentation_cannot_be_used() {
                 Binary::from(revoked_presentation.as_bytes()),
                 REVOCATION_ROUTE_ID,
                 Some(REVOCATION_TEST_CALLER.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()
@@ -170,6 +171,67 @@ fn test_revoked_presentation_cannot_be_used() {
                 Binary::from(valid_presentation.as_bytes()),
                 REVOCATION_ROUTE_ID,
                 Some(REVOCATION_TEST_CALLER.to_string()),
+                None,
+            )
+            .call(FIRST_CALLER_APP_ADDR)
+            .unwrap()
+            .data
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert!(res.result.is_ok());
+}
+
+#[test]
+fn test_addition_requirements_with_revocation_list() {
+    let revoked_idx = 111;
+
+    let app: App<_> = App::default();
+
+    // Instantiate verifier contract with some predefined parameters
+    // By default there is no revocation list
+    let (contract, _) =
+        instantiate_verifier_contract(&app, RouteVerificationRequirementsType::Supported);
+
+    // Now we create additional requirements for the route
+    let addition_requirement = vec![(
+        "idx".to_string(),
+        Criterion::NotContainedIn(vec![revoked_idx]),
+    )];
+
+    // Make a presentation with some claims
+    let revoked_claims = claims_with_revocation_idx("Alice", 30, true, 2021, None, revoked_idx);
+
+    let revoked_presentation =
+        make_presentation(revoked_claims, PresentationVerificationType::Success);
+
+    // Additional requirements should be checked if revoked_claims is revoked and should error
+    let res: VerifyResult = from_json(
+        contract
+            .verify(
+                Binary::from(revoked_presentation.as_bytes()),
+                FIRST_ROUTE_ID,
+                Some(FIRST_CALLER_APP_ADDR.to_string()),
+                Some(to_json_binary(&addition_requirement).unwrap()),
+            )
+            .call(FIRST_CALLER_APP_ADDR)
+            .unwrap()
+            .data
+            .unwrap(),
+    )
+    .unwrap();
+    let err = res.result.unwrap_err();
+    assert_eq!(err, SdjwtVerifierResultError::IdxRevoked(revoked_idx));
+
+    // Additional requirements not present, revoked_claims is not checked and should ok
+    let res: VerifyResult = from_json(
+        contract
+            .verify(
+                Binary::from(revoked_presentation.as_bytes()),
+                FIRST_ROUTE_ID,
+                Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()

--- a/contracts/sdjwt-verifier/src/tests/fixtures.rs
+++ b/contracts/sdjwt-verifier/src/tests/fixtures.rs
@@ -5,7 +5,7 @@ use avida_test_utils::sdjwt::fixtures::{
 };
 use sylvia::multitest::{App, Proxy};
 
-use avida_common::types::{InputRoutesRequirements, RouteVerificationRequirements};
+use avida_common::types::{RegisterRouteRequest, RouteVerificationRequirements};
 
 use cw_multi_test::App as MtApp;
 
@@ -33,7 +33,7 @@ pub fn instantiate_verifier_contract(
     let init_registrations = vec![InitRegistration {
         app_admin: FIRST_CALLER_APP_ADDR.to_string(),
         app_addr: FIRST_CALLER_APP_ADDR.to_string(),
-        routes: vec![InputRoutesRequirements {
+        routes: vec![RegisterRouteRequest {
             route_id: FIRST_ROUTE_ID,
             requirements: fx_route_verification_req.clone(),
         }],

--- a/contracts/sdjwt-verifier/src/tests/mod.rs
+++ b/contracts/sdjwt-verifier/src/tests/mod.rs
@@ -1,2 +1,3 @@
+mod contract_test;
 mod fixtures;
-pub mod verifier_test;
+mod verifier_test;

--- a/contracts/sdjwt-verifier/src/tests/verifier_test.rs
+++ b/contracts/sdjwt-verifier/src/tests/verifier_test.rs
@@ -4,9 +4,9 @@ use sylvia::multitest::App;
 
 use crate::contract::sv::mt::SdjwtVerifierProxy;
 use crate::errors::{SdjwtVerifierError, SdjwtVerifierResultError};
-use crate::verifier::VerifyResult;
+use crate::types::VerifyResult;
 use avida_common::traits::avida_verifier_trait::sv::mt::AvidaVerifierTraitProxy;
-use avida_common::types::InputRoutesRequirements;
+use avida_common::types::RegisterRouteRequest;
 use serde::{Deserialize, Serialize};
 
 use josekit::{self};
@@ -47,13 +47,13 @@ fn instantiate_success() {
         .unwrap();
 
     assert_eq!(
-        registered_req.verification_source,
-        fx_route_verification_req.verification_source
+        registered_req.issuer_source_or_data,
+        fx_route_verification_req.issuer_source_or_data
     );
 
     assert_eq!(
-        registered_req.presentation_request,
-        fx_route_verification_req.presentation_request
+        registered_req.presentation_required,
+        fx_route_verification_req.presentation_required
     );
 
     let route_verification_key = contract
@@ -114,7 +114,7 @@ fn verify_success_exp_validate_success() {
     contract
         .register(
             SECOND_CALLER_APP_ADDR.to_string(),
-            vec![InputRoutesRequirements {
+            vec![RegisterRouteRequest {
                 route_id: SECOND_ROUTE_ID,
                 requirements: route_verification_req,
             }],
@@ -204,7 +204,7 @@ fn verify_failed_on_expired_claim() {
     contract
         .register(
             SECOND_CALLER_APP_ADDR.to_string(),
-            vec![InputRoutesRequirements {
+            vec![RegisterRouteRequest {
                 route_id: SECOND_ROUTE_ID,
                 requirements: route_verification_req,
             }],
@@ -286,7 +286,7 @@ fn verify_sucess_on_no_expiration_check_for_expired_claims() {
     contract
         .register(
             SECOND_CALLER_APP_ADDR.to_string(),
-            vec![InputRoutesRequirements {
+            vec![RegisterRouteRequest {
                 route_id: SECOND_ROUTE_ID,
                 requirements: route_verification_req,
             }],
@@ -513,17 +513,17 @@ fn register_success() {
         .unwrap();
 
     assert_eq!(
-        second_registered_req.verification_source,
+        second_registered_req.issuer_source_or_data,
         two_routes_verification_req[0]
             .requirements
-            .verification_source
+            .issuer_source_or_data
     );
 
     assert_eq!(
-        second_registered_req.presentation_request,
+        second_registered_req.presentation_required,
         two_routes_verification_req[0]
             .requirements
-            .presentation_request
+            .presentation_required
     );
 
     let route_verification_key = contract
@@ -541,17 +541,17 @@ fn register_success() {
         .unwrap();
 
     assert_eq!(
-        third_registered_req.verification_source,
+        third_registered_req.issuer_source_or_data,
         two_routes_verification_req[1]
             .requirements
-            .verification_source
+            .issuer_source_or_data
     );
 
     assert_eq!(
-        third_registered_req.presentation_request,
+        third_registered_req.presentation_required,
         two_routes_verification_req[1]
             .requirements
-            .presentation_request
+            .presentation_required
     );
 
     let route_verification_key = contract
@@ -611,7 +611,7 @@ fn register_serde_json_error() {
     // Make invalid presentation request
     two_routes_verification_req[0]
         .requirements
-        .presentation_request = Binary::from(b"invalid");
+        .presentation_required = Binary::from(b"invalid");
 
     // Try register the app with the two routes and invalid presentation request
     assert!(matches!(
@@ -769,13 +769,13 @@ fn update_success() {
         .unwrap();
 
     assert_eq!(
-        updated_registered_req.verification_source,
-        updated_route_verification_req.verification_source
+        updated_registered_req.issuer_source_or_data,
+        updated_route_verification_req.issuer_source_or_data
     );
 
     assert_eq!(
-        updated_registered_req.presentation_request,
-        updated_route_verification_req.presentation_request
+        updated_registered_req.presentation_required,
+        updated_route_verification_req.presentation_required
     );
 
     // Ensure that the route verification requirements are updated
@@ -882,7 +882,7 @@ fn update_serde_json_error() {
     );
 
     // Try update the route verification requirements with invalid presentation request
-    updated_route_verification_req.presentation_request = Binary::from(b"invalid");
+    updated_route_verification_req.presentation_required = Binary::from(b"invalid");
 
     assert!(matches!(
         contract
@@ -914,7 +914,7 @@ fn update_unsupported_key_type() {
     assert!(contract
         .register(
             SECOND_CALLER_APP_ADDR.to_string(),
-            vec![InputRoutesRequirements {
+            vec![RegisterRouteRequest {
                 route_id: SECOND_ROUTE_ID,
                 requirements: route_verification_req
             }]

--- a/contracts/sdjwt-verifier/src/tests/verifier_test.rs
+++ b/contracts/sdjwt-verifier/src/tests/verifier_test.rs
@@ -86,6 +86,7 @@ fn verify_success_no_exp_validate_success() {
                 Binary::from(presentation.as_bytes()),
                 FIRST_ROUTE_ID,
                 Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()
@@ -144,6 +145,7 @@ fn verify_success_exp_validate_success() {
                 Binary::from(presentation.as_bytes()),
                 SECOND_ROUTE_ID,
                 Some(SECOND_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(SECOND_CALLER_APP_ADDR)
             .unwrap()
@@ -176,6 +178,7 @@ fn verify_success_exp_validate_success() {
                 Binary::from(presentation.as_bytes()),
                 SECOND_ROUTE_ID,
                 Some(SECOND_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(SECOND_CALLER_APP_ADDR)
             .unwrap()
@@ -227,6 +230,7 @@ fn verify_failed_on_expired_claim() {
                 Binary::from(presentation.as_bytes()),
                 SECOND_ROUTE_ID,
                 Some(SECOND_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(SECOND_CALLER_APP_ADDR)
             .unwrap()
@@ -255,6 +259,7 @@ fn verify_failed_on_expired_claim() {
                 Binary::from(presentation.as_bytes()),
                 SECOND_ROUTE_ID,
                 Some(SECOND_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(SECOND_CALLER_APP_ADDR)
             .unwrap()
@@ -309,6 +314,7 @@ fn verify_sucess_on_no_expiration_check_for_expired_claims() {
                 Binary::from(presentation.as_bytes()),
                 SECOND_ROUTE_ID,
                 Some(SECOND_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(SECOND_CALLER_APP_ADDR)
             .unwrap()
@@ -339,6 +345,7 @@ fn verify_success_validate_fails() {
                 Binary::from(presentation.as_bytes()),
                 FIRST_ROUTE_ID,
                 Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()
@@ -370,6 +377,7 @@ fn verify_required_claims_not_satisfied() {
                 Binary::from(presentation.as_bytes()),
                 FIRST_ROUTE_ID,
                 Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()
@@ -401,6 +409,7 @@ fn verify_without_sdjwt() {
                 Binary::from(b""),
                 FIRST_ROUTE_ID,
                 Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()
@@ -441,6 +450,7 @@ fn verify_presentation_too_large() {
                 Binary::from(presentation.as_bytes()),
                 FIRST_ROUTE_ID,
                 Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR)
             .unwrap()
@@ -475,6 +485,7 @@ fn verify_route_not_registered() {
                 Binary::from(presentation.as_bytes()),
                 SECOND_ROUTE_ID,
                 Some(FIRST_CALLER_APP_ADDR.to_string()),
+                None,
             )
             .call(FIRST_CALLER_APP_ADDR),
         Err(SdjwtVerifierError::RouteNotRegistered)

--- a/contracts/sdjwt-verifier/src/types.rs
+++ b/contracts/sdjwt-verifier/src/types.rs
@@ -7,7 +7,11 @@ use cw_utils::Expiration;
 use jsonwebtoken::jwk::Jwk;
 use serde::{Deserialize, Serialize};
 
+/// This is the key to be used in claims that specifies expiration using `cw_util::Expiration`
 pub const CW_EXPIRATION: &str = "cw_exp";
+
+/// This is the  key to be used in revocation_list in Criterion::NotContainedIn(revocation_list)
+pub const IDX: &str = "idx";
 
 #[cw_serde]
 pub struct VerifyResult {
@@ -82,6 +86,9 @@ pub enum Criterion {
     Number(u64, MathsOperator),
     Boolean(bool),
     Expires(bool),
+    /// this can be used in any form,
+    /// but it is designed to be used with key IDX as a revocationlist
+    NotContainedIn(Vec<u64>),
 }
 
 #[cw_serde]
@@ -89,6 +96,15 @@ pub enum MathsOperator {
     GreaterThan,
     LessThan,
     EqualTo,
+}
+
+/// A Sd-jwt specific requirement for revocation list update
+/// using Criterion::NotContainedIn
+#[cw_serde]
+pub struct UpdateRevocationListRequest {
+    pub route_id: u64,
+    pub revoke: Vec<u64>,
+    pub unrevoke: Vec<u64>,
 }
 
 /// Validate the verified claims against the presentation request

--- a/contracts/sdjwt-verifier/src/verifier.rs
+++ b/contracts/sdjwt-verifier/src/verifier.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use crate::{
     contract::SdjwtVerifier,
     errors::{SdjwtVerifierError, SdjwtVerifierResultError},
-    types::{validate, PendingRoute, VerificationRequirements, VerifyResult, _RegistrationRequest},
+    types::{
+        validate, PendingRoute, PresentationReq, VerificationRequirements, VerifyResult,
+        _RegistrationRequest,
+    },
 };
 
 // AVIDA specific
@@ -21,8 +24,8 @@ use avida_common::{
 
 //  CosmWasm / Sylvia lib
 use cosmwasm_std::{
-    ensure, from_json, to_json_binary, Addr, BlockInfo, CosmosMsg, Env, IbcTimeout, Response,
-    Storage, SubMsg,
+    ensure, from_json, to_json_binary, Addr, Binary, BlockInfo, CosmosMsg, Env, IbcTimeout,
+    Response, Storage, SubMsg,
 };
 
 use sylvia::{
@@ -50,7 +53,10 @@ impl AvidaVerifierTrait for SdjwtVerifier<'_> {
                 app_addr,
                 route_id,
                 presentation,
+                additional_requirements,
             } => {
+                let additional_requirements: Option<PresentationReq> =
+                    additional_requirements.map(from_json).transpose()?;
                 // If app is registered, load the requirementes for the given route_id
                 let requirements = self
                     .app_routes_requirements
@@ -62,7 +68,13 @@ impl AvidaVerifierTrait for SdjwtVerifier<'_> {
 
                 // In `Sudo`, the app address may be the `moduleAccount`
                 Ok(self
-                    ._verify(presentation, requirements, max_len, &env.block)
+                    ._verify(
+                        presentation,
+                        requirements,
+                        max_len,
+                        &env.block,
+                        additional_requirements,
+                    )
                     .map(|_| Response::default())
                     .map_err(SdjwtVerifierError::SdjwtVerifierResultError)?)
             }
@@ -102,8 +114,12 @@ impl AvidaVerifierTrait for SdjwtVerifier<'_> {
         presentation: VerfiablePresentation,
         route_id: RouteId,
         app_addr: Option<String>,
+        additional_requirements: Option<Binary>,
     ) -> Result<Response, Self::Error> {
         let ExecCtx { deps, info, env } = ctx;
+
+        let additional_requirements: Option<PresentationReq> =
+            additional_requirements.map(from_json).transpose()?;
         let app_addr = app_addr.unwrap_or_else(|| info.sender.to_string());
         let app_addr = deps.api.addr_validate(&app_addr)?;
 
@@ -116,7 +132,13 @@ impl AvidaVerifierTrait for SdjwtVerifier<'_> {
             .clone();
         let max_len = self.max_presentation_len.load(deps.storage)?;
         // Performs the verification of the provided presentation within the context of the given route
-        let res = self._verify(presentation, requirements, max_len, &env.block);
+        let res = self._verify(
+            presentation,
+            requirements,
+            max_len,
+            &env.block,
+            additional_requirements,
+        );
 
         //:we response with the error so that it can be propagated
         Ok(Response::default().set_data(to_json_binary(&VerifyResult { result: res })?))
@@ -230,6 +252,7 @@ impl SdjwtVerifier<'_> {
         requirements: VerificationRequirements,
         max_presentation_len: usize,
         block_info: &BlockInfo,
+        additional_requirements: Option<PresentationReq>,
     ) -> Result<(), SdjwtVerifierResultError> {
         // Ensure the presentation is not too large
         ensure!(
@@ -257,12 +280,16 @@ impl SdjwtVerifier<'_> {
         .map_err(|e| SdjwtVerifierResultError::SdJwt(e.to_string()))?
         .verified_claims;
 
+        let combined_requirements = if let Some(additional_requirements) = additional_requirements {
+            let mut combined_requirements = requirements.presentation_required.clone();
+            combined_requirements.extend(additional_requirements);
+            combined_requirements
+        } else {
+            requirements.presentation_required.clone()
+        };
+
         // We validate the verified claims against the requirements
-        validate(
-            requirements.presentation_required,
-            verified_claims,
-            block_info,
-        )
+        validate(combined_requirements, verified_claims, block_info)
     }
 
     /// Performs a registration of an application and all its routes

--- a/packages/avida_test_utils/src/sdjwt/fixtures.rs
+++ b/packages/avida_test_utils/src/sdjwt/fixtures.rs
@@ -103,6 +103,30 @@ pub fn claims(name: &str, age: u8, active: bool, joined_at: u16, exp: Option<Exp
     })
 }
 
+pub fn claims_with_revocation_idx(
+    name: &str,
+    age: u8,
+    active: bool,
+    joined_at: u16,
+    exp: Option<Expiration>,
+    idx: u64,
+) -> Value {
+    let exp = match exp {
+        Some(exp) => serde_json_wasm::to_string(&exp).unwrap(),
+        None => "".to_string(),
+    };
+    serde_json::json!({
+        CW_EXPIRATION: exp,
+        "iss": "issuer",
+        "name": name,
+        "age": age,
+        "active": active,
+        "joined_at": joined_at,
+        IDX: idx
+
+    })
+}
+
 /// Make a presentation corresponding to the claims provided and the presentation verification error type
 pub fn make_presentation(
     claims: Value,
@@ -163,15 +187,8 @@ pub fn make_route_verification_requirements(
 }
 
 pub fn get_route_requirement_with_empty_revocation_list(route_id: u64) -> RegisterRouteRequest {
-    let first_presentation_req: PresentationReq = vec![
-        ("name".to_string(), Criterion::String("John".to_string())),
-        (
-            "age".to_string(),
-            Criterion::Number(24, MathsOperator::EqualTo),
-        ),
-        ("active".to_string(), Criterion::Boolean(true)),
-        (IDX.to_string(), Criterion::NotContainedIn(vec![])),
-    ];
+    let first_presentation_req: PresentationReq =
+        vec![(IDX.to_string(), Criterion::NotContainedIn(vec![]))];
 
     RegisterRouteRequest {
         route_id,

--- a/packages/avida_test_utils/src/sdjwt/fixtures.rs
+++ b/packages/avida_test_utils/src/sdjwt/fixtures.rs
@@ -144,10 +144,8 @@ pub fn make_presentation(
         )
         .unwrap();
 
+    // default all claims are disclosed
     let mut claims_to_disclosure = claims;
-    claims_to_disclosure["age"] = Value::Bool(true);
-    claims_to_disclosure["active"] = Value::Bool(true);
-    claims_to_disclosure["joined_at"] = Value::Bool(true);
 
     if let PresentationVerificationType::OmitAgeDisclosure = presentation_verification_type {
         claims_to_disclosure["age"] = Value::Bool(false);

--- a/packages/avida_test_utils/src/sdjwt/fixtures.rs
+++ b/packages/avida_test_utils/src/sdjwt/fixtures.rs
@@ -10,7 +10,7 @@ use std::{fs, path::PathBuf};
 use cosmwasm_std::{Binary, Timestamp};
 
 use avida_common::types::{
-    InputRoutesRequirements, RouteVerificationRequirements, VerificationSource,
+    IssuerSourceOrData, RegisterRouteRequest, RouteVerificationRequirements,
 };
 use avida_sdjwt_verifier::types::{Criterion, MathsOperator, PresentationReq, CW_EXPIRATION};
 use josekit::{self};
@@ -153,16 +153,16 @@ pub fn make_route_verification_requirements(
 
     // Add some default criteria as presentation request
     RouteVerificationRequirements {
-        verification_source: VerificationSource {
+        issuer_source_or_data: IssuerSourceOrData {
             source: None,
             data_or_location: Binary::from(data_or_location.as_bytes()),
         },
-        presentation_request: Binary::from(re.as_bytes()),
+        presentation_required: Binary::from(re.as_bytes()),
     }
 }
 
 /// Is used to get input verification requirements for 2 routes
-pub fn get_two_input_routes_requirements() -> Vec<InputRoutesRequirements> {
+pub fn get_two_input_routes_requirements() -> Vec<RegisterRouteRequest> {
     let first_presentation_req: PresentationReq = vec![
         ("name".to_string(), Criterion::String("John".to_string())),
         (
@@ -182,14 +182,14 @@ pub fn get_two_input_routes_requirements() -> Vec<InputRoutesRequirements> {
     ];
 
     vec![
-        InputRoutesRequirements {
+        RegisterRouteRequest {
             route_id: SECOND_ROUTE_ID,
             requirements: make_route_verification_requirements(
                 first_presentation_req,
                 RouteVerificationRequirementsType::Supported,
             ),
         },
-        InputRoutesRequirements {
+        RegisterRouteRequest {
             route_id: THIRD_ROUTE_ID,
             requirements: make_route_verification_requirements(
                 second_presentation_req,
@@ -225,7 +225,7 @@ pub fn get_route_verification_requirement(
 /// Is used to get route verification requirements for a single route
 pub fn get_input_route_requirement(
     route_verification_requirements_type: RouteVerificationRequirementsType,
-) -> InputRoutesRequirements {
+) -> RegisterRouteRequest {
     let presentation_req: PresentationReq = vec![
         (
             "age".to_string(),
@@ -237,7 +237,7 @@ pub fn get_input_route_requirement(
             Criterion::Number(2020, MathsOperator::GreaterThan),
         ),
     ];
-    InputRoutesRequirements {
+    RegisterRouteRequest {
         route_id: SECOND_ROUTE_ID,
         requirements: make_route_verification_requirements(
             presentation_req,

--- a/packages/avida_test_utils/src/sdjwt/fixtures.rs
+++ b/packages/avida_test_utils/src/sdjwt/fixtures.rs
@@ -1,3 +1,4 @@
+use avida_sdjwt_verifier::types::IDX;
 use cosmwasm_std::BlockInfo;
 use cw_utils::Expiration;
 use jsonwebtoken::EncodingKey;
@@ -158,6 +159,26 @@ pub fn make_route_verification_requirements(
             data_or_location: Binary::from(data_or_location.as_bytes()),
         },
         presentation_required: Binary::from(re.as_bytes()),
+    }
+}
+
+pub fn get_route_requirement_with_empty_revocation_list(route_id: u64) -> RegisterRouteRequest {
+    let first_presentation_req: PresentationReq = vec![
+        ("name".to_string(), Criterion::String("John".to_string())),
+        (
+            "age".to_string(),
+            Criterion::Number(24, MathsOperator::EqualTo),
+        ),
+        ("active".to_string(), Criterion::Boolean(true)),
+        (IDX.to_string(), Criterion::NotContainedIn(vec![])),
+    ];
+
+    RegisterRouteRequest {
+        route_id,
+        requirements: make_route_verification_requirements(
+            first_presentation_req,
+            RouteVerificationRequirementsType::Supported,
+        ),
     }
 }
 

--- a/packages/common/src/traits.rs
+++ b/packages/common/src/traits.rs
@@ -2,7 +2,7 @@ use crate::types::{
     AvidaVerifierSudoMsg, RegisterRouteRequest, RouteId, RouteVerificationRequirements,
     VerfiablePresentation,
 };
-use cosmwasm_std::{Response, StdError};
+use cosmwasm_std::{Binary, Response, StdError};
 use sylvia::types::{ExecCtx, QueryCtx, SudoCtx};
 use sylvia::{interface, schemars};
 
@@ -27,6 +27,8 @@ pub mod avida_verifier_trait {
         ) -> Result<Response, Self::Error>;
 
         /// Verifiable Presentation Verifier for dApp contracts
+        /// additional_requirements is the dynamic added (per tx) requirements that can be passed to the verifier at the
+        /// time of verification, for sdjwt, it is requirement for claims kv pair
         #[sv::msg(exec)]
         fn verify(
             &self,
@@ -34,6 +36,7 @@ pub mod avida_verifier_trait {
             presentation: VerfiablePresentation,
             route_id: RouteId,
             app_addr: Option<String>,
+            additional_requirements: Option<Binary>,
         ) -> Result<Response, Self::Error>;
 
         // For dApp to update their criteria verification criteria

--- a/packages/common/src/traits.rs
+++ b/packages/common/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    AvidaVerifierSudoMsg, InputRoutesRequirements, RouteId, RouteVerificationRequirements,
+    AvidaVerifierSudoMsg, RegisterRouteRequest, RouteId, RouteVerificationRequirements,
     VerfiablePresentation,
 };
 use cosmwasm_std::{Response, StdError};
@@ -23,7 +23,7 @@ pub mod avida_verifier_trait {
             &self,
             ctx: ExecCtx,
             app_addr: String,
-            route_criteria: Vec<InputRoutesRequirements>,
+            requests: Vec<RegisterRouteRequest>,
         ) -> Result<Response, Self::Error>;
 
         /// Verifiable Presentation Verifier for dApp contracts

--- a/packages/common/src/types.rs
+++ b/packages/common/src/types.rs
@@ -25,7 +25,7 @@ pub struct RouteVerificationRequirements {
     pub issuer_source_or_data: IssuerSourceOrData,
     /// The presentation request is the criteria required for the presentation,
     /// for example required certains claims to be disclosed
-    /// This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier
+    /// This value is stored as `VerificationRequirements.presentation_required` on sdjwtVerifier
     pub presentation_required: Binary,
 }
 
@@ -52,5 +52,6 @@ pub enum AvidaVerifierSudoMsg {
         route_id: RouteId,
         presentation: Binary,
         app_addr: String,
+        additional_requirements: Option<Binary>,
     },
 }

--- a/packages/common/src/types.rs
+++ b/packages/common/src/types.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Binary;
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::Item;
 
 /// This is set for the verifier to prevent the presentation from being too large
 pub type MaxPresentationLen<'a> = Item<'a, usize>;
@@ -9,15 +9,11 @@ pub const MAX_PRESENTATION_LEN: MaxPresentationLen = Item::new("mpl");
 /// The verifiable presentation type is encoded as Binary
 pub type VerfiablePresentation = Binary;
 
-/// For each route registered by a dApp smart contract,
-/// the requirements are stored and updatable
-pub type VerificationRequirements<'a> = Map<'a, RouteId, RouteVerificationRequirements>;
-
 pub type RouteId = u64;
 
 /// Routes Requiments used in Registration (and Initiation)
 #[cw_serde]
-pub struct InputRoutesRequirements {
+pub struct RegisterRouteRequest {
     pub route_id: RouteId,
     pub requirements: RouteVerificationRequirements,
 }
@@ -26,11 +22,11 @@ pub struct InputRoutesRequirements {
 #[cw_serde]
 pub struct RouteVerificationRequirements {
     /// This defines where the source data for verification is
-    pub verification_source: VerificationSource,
+    pub issuer_source_or_data: IssuerSourceOrData,
     /// The presentation request is the criteria required for the presentation,
     /// for example required certains claims to be disclosed
     /// This value is stored as `VerificationReq.presentation_required` on sdjwtVerifier
-    pub presentation_request: Binary,
+    pub presentation_required: Binary,
 }
 
 #[cw_serde]
@@ -40,7 +36,7 @@ pub enum TrustRegistry {
 
 /// Location to obtain the verification data from
 #[cw_serde]
-pub struct VerificationSource {
+pub struct IssuerSourceOrData {
     /// If `None`, this means data is directly provided
     pub source: Option<TrustRegistry>,
     /// The data or location of the verification data at the trust registry


### PR DESCRIPTION
This addresses 
- allowing caller of `verify` method to add additional requirements at each call
- add a criterion enum var for `NotContainedIn` allowing revocation list type verification
- update avida-ts (still have unsolved rpc request size with underlying cosmes, so removed none critical query in `avida-example` contract for now)

